### PR TITLE
[FIX] 회원 정보 수정 카테고리 업데이트 로직 개선

### DIFF
--- a/src/main/java/com/umc/devine/domain/category/repository/MemberCategoryRepository.java
+++ b/src/main/java/com/umc/devine/domain/category/repository/MemberCategoryRepository.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 public interface MemberCategoryRepository extends JpaRepository<MemberCategory, Long> {
     List<MemberCategory> findAllByMember(Member member);
-    void deleteAllByMember(Member member);
 
     @Query("SELECT mc FROM MemberCategory mc JOIN FETCH mc.category WHERE mc.member = :member")
     List<MemberCategory> findAllByMemberWithCategory(@Param("member") Member member);

--- a/src/main/java/com/umc/devine/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/devine/domain/member/entity/Member.java
@@ -1,5 +1,7 @@
 package com.umc.devine.domain.member.entity;
 
+import com.umc.devine.domain.category.entity.Category;
+import com.umc.devine.domain.category.entity.mapping.MemberCategory;
 import com.umc.devine.domain.member.dto.MemberReqDTO;
 import com.umc.devine.domain.member.enums.MemberMainType;
 import com.umc.devine.domain.member.enums.MemberStatus;
@@ -7,6 +9,8 @@ import com.umc.devine.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Entity
@@ -62,6 +66,10 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 20)
     private MemberStatus used;
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<MemberCategory> memberCategories = new ArrayList<>();
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
@@ -97,6 +105,19 @@ public class Member extends BaseEntity {
 
     public void updateGithubUsername(String githubUsername) {
         this.githubUsername = githubUsername;
+    }
+
+    public void clearCategories() {
+        this.memberCategories.clear();
+    }
+
+    public void addCategories(List<Category> categories) {
+        categories.forEach(category ->
+            this.memberCategories.add(MemberCategory.builder()
+                    .member(this)
+                    .category(category)
+                    .build())
+        );
     }
 
     /**

--- a/src/main/java/com/umc/devine/domain/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/com/umc/devine/domain/member/exception/code/MemberErrorCode.java
@@ -51,6 +51,9 @@ public enum MemberErrorCode implements BaseErrorCode {
     GITHUB_USERNAME_NOT_FOUND(HttpStatus.NOT_FOUND,
             "MEMBER404_5",
             "GitHub 사용자명이 등록되지 않았습니다."),
+    CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST,
+            "MEMBER400_5",
+            "관심 도메인은 최소 1개 이상 선택해야 합니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/umc/devine/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/umc/devine/domain/member/service/command/MemberCommandServiceImpl.java
@@ -40,6 +40,7 @@ import com.umc.devine.global.dto.PagedResponse;
 import com.umc.devine.global.security.ClerkPrincipal;
 import com.umc.devine.infrastructure.github.GitHubService;
 import com.umc.devine.infrastructure.github.dto.GitHubRepositoryDTO;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -71,6 +72,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final GitRepoUrlRepository gitRepoUrlRepository;
     private final GitHubService gitHubService;
     private final DevReportRepository devReportRepository;
+    private final EntityManager entityManager;
 
     @Override
     public MemberResDTO.SignupResultDTO signup(ClerkPrincipal principal, MemberReqDTO.SignupDTO dto) {
@@ -164,15 +166,18 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         // 멤버 업데이트
         member.updateProfile(dto);
 
-        // 카테고리 업데이트
-        if (dto.domains() != null && dto.domains().length > 0) {
-            memberCategoryRepository.deleteAllByMember(member);
-
+        // 카테고리 업데이트 (orphanRemoval + flush로 DELETE 후 INSERT 보장)
+        if (dto.domains() != null) {
+            if (dto.domains().length == 0) {
+                throw new MemberException(MemberErrorCode.CATEGORY_REQUIRED);
+            }
             List<Category> categories = categoryRepository.findAllByGenreIn(Arrays.asList(dto.domains()));
             if (categories.size() != dto.domains().length) {
                 throw new MemberException(MemberErrorCode.CATEGORY_NOT_FOUND);
             }
-            memberCategoryRepository.saveAll(CategoryConverter.toMemberCategories(member, categories));
+            member.clearCategories();
+            entityManager.flush();  // DELETE 먼저 실행
+            member.addCategories(categories);
         }
 
         // 연락처 업데이트

--- a/src/test/java/com/umc/devine/domain/member/service/command/MemberCommandServiceTest.java
+++ b/src/test/java/com/umc/devine/domain/member/service/command/MemberCommandServiceTest.java
@@ -8,6 +8,7 @@ import com.umc.devine.domain.member.dto.MemberReqDTO;
 import com.umc.devine.domain.member.dto.MemberResDTO;
 import com.umc.devine.domain.member.entity.Member;
 import com.umc.devine.domain.member.entity.Terms;
+import com.umc.devine.domain.member.enums.ContactType;
 import com.umc.devine.domain.member.enums.MemberMainType;
 import com.umc.devine.domain.member.enums.MemberStatus;
 import com.umc.devine.domain.member.exception.MemberException;
@@ -298,6 +299,60 @@ class MemberCommandServiceTest extends IntegrationTestSupport {
             // then
             assertThat(result.member().nickname()).isEqualTo("testuser");
             assertThat(result.member().body()).isEqualTo("자기소개만 수정");
+        }
+
+        @Test
+        @DisplayName("카테고리 업데이트 성공")
+        void updateMember_categoryUpdate_success() {
+            // given
+            Category newCategory = categoryRepository.save(Category.builder()
+                    .genre(CategoryGenre.FINTECH)
+                    .build());
+
+            MemberReqDTO.UpdateMemberDTO dto = MemberReqDTO.UpdateMemberDTO.builder()
+                    .domains(new CategoryGenre[] {CategoryGenre.FINTECH})
+                    .build();
+
+            // when
+            MemberResDTO.MemberProfileDTO result = memberCommandService.updateMember(testMember, dto);
+
+            // then
+            assertThat(result.domains()).hasSize(1);
+            assertThat(result.domains()).contains(CategoryGenre.FINTECH);
+        }
+
+        @Test
+        @DisplayName("빈 카테고리 배열로 수정 시 예외 발생")
+        void updateMember_emptyCategories_throwsException() {
+            // given
+            MemberReqDTO.UpdateMemberDTO dto = MemberReqDTO.UpdateMemberDTO.builder()
+                    .domains(new CategoryGenre[] {})
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> memberCommandService.updateMember(testMember, dto))
+                    .isInstanceOf(MemberException.class);
+        }
+
+        @Test
+        @DisplayName("연락처 업데이트 성공")
+        void updateMember_contactUpdate_success() {
+            // given
+            MemberReqDTO.ContactDTO contactDTO = MemberReqDTO.ContactDTO.builder()
+                    .type(ContactType.EMAIL)
+                    .value("updated@example.com")
+                    .build();
+
+            MemberReqDTO.UpdateMemberDTO dto = MemberReqDTO.UpdateMemberDTO.builder()
+                    .contacts(new MemberReqDTO.ContactDTO[] {contactDTO})
+                    .build();
+
+            // when
+            MemberResDTO.MemberProfileDTO result = memberCommandService.updateMember(testMember, dto);
+
+            // then
+            assertThat(result.contacts()).hasSize(1);
+            assertThat(result.contacts().get(0).value()).isEqualTo("updated@example.com");
         }
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호
- issue #180

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

- 기존 카테고리 업데이트 방식(deleteAll + saveAll)에서 orphanRemoval 기반(clearCategories + flush + addCategories)으로 변경하여 영속성 컨텍스트 불일치 문제 해결
- Member 엔티티에 MemberCategory 양방향 매핑 추가 (cascade ALL, orphanRemoval)
- 빈 카테고리 배열 입력 시 CATEGORY_REQUIRED 에러코드 추가
- MemberCategoryRepository에서 미사용 deleteAllByMember 메서드 제거

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

- 기존 멤버 테스트 전체 통과 (100%)
- 새로 추가한 테스트 케이스:
  - 카테고리 업데이트 성공 검증
  - 빈 카테고리 배열 입력 시 예외 발생 검증
  - 연락처 업데이트 성공 검증

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
