### PR TITLE
[FIX] 메인 권한 관계없이 프로젝트 목록 조회 수정

### DIFF
--- a/src/main/java/com/umc/devine/domain/project/repository/MatchingRepository.java
+++ b/src/main/java/com/umc/devine/domain/project/repository/MatchingRepository.java
@@ -78,7 +78,7 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
             @Param("excludeStatus") MatchingStatus excludeStatus,
             Pageable pageable);
 
-    // 내 프로젝트 조회 - 개발자 분기: 수락된 매칭 기반 프로젝트 상태별 조회
+    // 내 프로젝트 조회 - 개발자 분기: 수락된 매칭 기반 프로젝트 상태별 조회 (페이징)
     @Query(value = "SELECT m FROM Matching m " +
             "JOIN FETCH m.project p " +
             "JOIN FETCH p.member pm " +
@@ -97,6 +97,20 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
             @Param("decision") MatchingDecision decision,
             @Param("projectStatuses") List<ProjectStatus> projectStatuses,
             Pageable pageable);
+
+    // 내 프로젝트 조회 - 수락된 매칭 기반 전체 조회 (비페이징, 내 프로젝트 통합 조회용)
+    @Query("SELECT m FROM Matching m " +
+            "JOIN FETCH m.project p " +
+            "JOIN FETCH p.member pm " +
+            "JOIN FETCH p.category " +
+            "WHERE m.member = :developer " +
+            "AND m.decision = :decision " +
+            "AND p.status IN :projectStatuses " +
+            "ORDER BY m.createdAt DESC")
+    List<Matching> findAllByMemberAndDecisionAndProjectStatusIn(
+            @Param("developer") Member developer,
+            @Param("decision") MatchingDecision decision,
+            @Param("projectStatuses") List<ProjectStatus> projectStatuses);
 
     // 특정 프로젝트-회원-타입 매칭 조회 (CANCELLED 제외)
     @Query("SELECT m FROM Matching m " +

--- a/src/main/java/com/umc/devine/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/umc/devine/domain/project/repository/ProjectRepository.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectQueryDsl {
-    // PM용: 본인 프로젝트를 상태별로 조회
+    // PM용: 본인 프로젝트를 상태별로 조회 (페이징)
     @Query(value = "SELECT p FROM Project p " +
             "JOIN FETCH p.category " +
             "WHERE p.member = :member " +
@@ -29,6 +29,12 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, Project
             @Param("member") Member member,
             @Param("statuses") List<ProjectStatus> statuses,
             Pageable pageable);
+
+    // 내가 등록한 프로젝트를 상태별로 전체 조회 (비페이징, 내 프로젝트 통합 조회용)
+    @Query("SELECT p FROM Project p JOIN FETCH p.category WHERE p.member = :member AND p.status IN :statuses ORDER BY p.createdAt DESC")
+    List<Project> findAllByMemberAndStatusIn(
+            @Param("member") Member member,
+            @Param("statuses") List<ProjectStatus> statuses);
 
     Optional<Project> findByIdAndStatusNot(Long id, ProjectStatus status);
 

--- a/src/main/java/com/umc/devine/domain/project/service/query/ProjectQueryServiceImpl.java
+++ b/src/main/java/com/umc/devine/domain/project/service/query/ProjectQueryServiceImpl.java
@@ -2,7 +2,6 @@ package com.umc.devine.domain.project.service.query;
 
 import com.querydsl.core.types.Predicate;
 import com.umc.devine.domain.member.entity.Member;
-import com.umc.devine.domain.member.enums.MemberMainType;
 import com.umc.devine.domain.project.converter.ProjectConverter;
 import com.umc.devine.domain.project.dto.ProjectReqDTO;
 import com.umc.devine.domain.project.dto.ProjectResDTO;
@@ -32,9 +31,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.umc.devine.domain.project.exception.code.ProjectErrorCode.PROJECT_NOT_FOUND;
@@ -160,11 +161,52 @@ public class ProjectQueryServiceImpl implements ProjectQueryService {
 
     @Override
     public ProjectResDTO.MyProjectsRes getMyProjects(Member member, List<ProjectStatus> statuses, Pageable pageable) {
-        if (member.getMainType().equals(MemberMainType.PM)) {
-            return getMyProjectsForPm(member, statuses, pageable);
-        } else {
-            return getMyProjectsForDeveloper(member, statuses, pageable);
-        }
+        // 내가 등록한 프로젝트
+        List<ProjectResDTO.MyProjectInfo> createdInfos = projectRepository
+                .findAllByMemberAndStatusIn(member, statuses)
+                .stream()
+                .map(ProjectConverter::toMyProjectInfo)
+                .toList();
+
+        // 매칭 수락된 프로젝트
+        List<ProjectResDTO.MyProjectInfo> matchedInfos = matchingRepository
+                .findAllByMemberAndDecisionAndProjectStatusIn(member, MatchingDecision.ACCEPT, statuses)
+                .stream()
+                .map(ProjectConverter::toMyProjectInfo)
+                .toList();
+
+        // 중복 제거: 내가 등록한 프로젝트 우선, 매칭 프로젝트 중 중복 제외
+        Set<Long> createdProjectIds = createdInfos.stream()
+                .map(ProjectResDTO.MyProjectInfo::projectId)
+                .collect(Collectors.toSet());
+
+        List<ProjectResDTO.MyProjectInfo> combined = new ArrayList<>(createdInfos);
+        matchedInfos.stream()
+                .filter(info -> !createdProjectIds.contains(info.projectId()))
+                .forEach(combined::add);
+
+        // 수동 페이지네이션
+        int total = combined.size();
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), total);
+        List<ProjectResDTO.MyProjectInfo> pageContent = start >= total ? List.of() : combined.subList(start, end);
+
+        int pageSize = pageable.getPageSize();
+        int totalPages = pageSize == 0 ? 0 : (int) Math.ceil((double) total / pageSize);
+
+        PagedResponse<ProjectResDTO.MyProjectInfo> pagedResponse = PagedResponse.<ProjectResDTO.MyProjectInfo>builder()
+                .content(pageContent)
+                .page(pageable.getPageNumber() + 1)
+                .size(pageSize)
+                .totalElements(total)
+                .totalPages(totalPages)
+                .isFirst(pageable.getPageNumber() == 0)
+                .isLast(end >= total)
+                .build();
+
+        return ProjectResDTO.MyProjectsRes.builder()
+                .projects(pagedResponse)
+                .build();
     }
 
     // ==================== Private Methods ====================
@@ -253,29 +295,4 @@ public class ProjectQueryServiceImpl implements ProjectQueryService {
                 .build();
     }
 
-    private ProjectResDTO.MyProjectsRes getMyProjectsForPm(Member member, List<ProjectStatus> statuses, Pageable pageable) {
-        Page<Project> projectPage = projectRepository.findByMemberAndStatusIn(member, statuses, pageable);
-
-        List<ProjectResDTO.MyProjectInfo> infos = projectPage.getContent().stream()
-                .map(ProjectConverter::toMyProjectInfo)
-                .toList();
-
-        return ProjectResDTO.MyProjectsRes.builder()
-                .projects(PagedResponse.of(projectPage, infos))
-                .build();
-    }
-
-    private ProjectResDTO.MyProjectsRes getMyProjectsForDeveloper(Member member, List<ProjectStatus> statuses, Pageable pageable) {
-        Page<Matching> matchingPage = matchingRepository.findByMemberAndDecisionAndProjectStatusIn(
-                member, MatchingDecision.ACCEPT, statuses, pageable
-        );
-
-        List<ProjectResDTO.MyProjectInfo> infos = matchingPage.getContent().stream()
-                .map(ProjectConverter::toMyProjectInfo)
-                .toList();
-
-        return ProjectResDTO.MyProjectsRes.builder()
-                .projects(PagedResponse.of(matchingPage, infos))
-                .build();
-    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호
- issue #209 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

메인 권한에 따라 프로젝트 목록 조회 결과가 제한되던 로직을 수정하여, 메인 권한과 관계없이 다음 프로젝트가 정상적으로 조회되도록 통합했습니다.

- 사용자가 등록한 프로젝트
- 매칭 수락 상태로 참여 중인 프로젝트

기존에는 메인 권한이 개발자인 경우 프로젝트 목록이 빈 배열로 조회되는 문제가 있었으며, 이를 권한과 무관하게 프로젝트 참여/등록 여부 기준으로 조회되도록 수정했습니다.

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요