### PR TITLE
[Fix] 지원 수락된 프로젝트가 목록에 반환되지 않은 문제 수정

### DIFF
--- a/src/main/java/com/umc/devine/domain/project/service/query/ProjectQueryServiceImpl.java
+++ b/src/main/java/com/umc/devine/domain/project/service/query/ProjectQueryServiceImpl.java
@@ -168,14 +168,12 @@ public class ProjectQueryServiceImpl implements ProjectQueryService {
                 .map(ProjectConverter::toMyProjectInfo)
                 .toList();
 
-        // 매칭 수락된 프로젝트 (모집 중 탭은 내가 생성한 프로젝트만 표시)
-        List<ProjectResDTO.MyProjectInfo> matchedInfos = statuses.contains(ProjectStatus.RECRUITING)
-                ? List.of()
-                : matchingRepository
-                        .findAllByMemberAndDecisionAndProjectStatusIn(member, MatchingDecision.ACCEPT, statuses)
-                        .stream()
-                        .map(ProjectConverter::toMyProjectInfo)
-                        .toList();
+        // 매칭 수락된 프로젝트
+        List<ProjectResDTO.MyProjectInfo> matchedInfos = matchingRepository
+                .findAllByMemberAndDecisionAndProjectStatusIn(member, MatchingDecision.ACCEPT, statuses)
+                .stream()
+                .map(ProjectConverter::toMyProjectInfo)
+                .toList();
 
         // 중복 제거: 내가 등록한 프로젝트 우선, 매칭 프로젝트 중 중복 제외
         Set<Long> createdProjectIds = createdInfos.stream()


### PR DESCRIPTION
- 프로젝트를 List.of()로 제외하던 삼항 연산자를 제거하고, 모든 status에서 동일하게 matchingRepository.findAllByMemberAndDecisionAndProjectStatusIn()

IssueNum #216

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호
- issue #216 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

파일: src/main/java/com/umc/devine/domain/project/service/query/ProjectQuerySe
 rviceImpl.java (line 172-173)

~~~
 List<ProjectResDTO.MyProjectInfo> matchedInfos =
 statuses.contains(ProjectStatus.RECRUITING)
         ? List.of()   // ← 모집중일 때 매칭된 프로젝트를 빈 리스트로 반환
         :
 matchingRepository.findAllByMemberAndDecisionAndProjectStatusIn(member,
 MatchingDecision.ACCEPT, statuses)
~~~

 모집중 상태에서는 List.of()를 반환하여 수락된 프로젝트가 아예 조회되지 않음.
 프로젝트가 여러 포지션을 모집하는 경우, 일부 포지션이 수락되어도 프로젝트
 status는 RECRUITING을 유지할 수 있으므로 수락된 사용자에게도 보여야 함.


## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요