### PR TITLE
[FIX] PortOne 설정을 core 모듈로 이동

### DIFF
--- a/devine-api/src/main/resources/application.yml
+++ b/devine-api/src/main/resources/application.yml
@@ -48,13 +48,3 @@ github:
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
 
-# PortOne
-portone:
-  store-id: ${PORTONE_STORE_ID:}
-  api-secret: ${PORTONE_API_SECRET:}
-  base-url: https://api.portone.io
-  webhook-secret: ${PORTONE_WEBHOOK_SECRET:}
-  channel-key:
-    nhn-kcp: ${PORTONE_CHANNEL_KEY_NHN_KCP:}
-    kg-inicis: ${PORTONE_CHANNEL_KEY_KG_INICIS:}
-    kakaopay: ${PORTONE_CHANNEL_KEY_KAKAOPAY:}

--- a/devine-core/src/main/resources/core-defaults.yml
+++ b/devine-core/src/main/resources/core-defaults.yml
@@ -39,3 +39,14 @@ redis:
   channel:
     notification-prefix: "notification:user:"
     notification-pattern: "notification:user:*"
+
+# PortOne
+portone:
+  store-id: ${PORTONE_STORE_ID:}
+  api-secret: ${PORTONE_API_SECRET:}
+  base-url: https://api.portone.io
+  webhook-secret: ${PORTONE_WEBHOOK_SECRET:}
+  channel-key:
+    nhn-kcp: ${PORTONE_CHANNEL_KEY_NHN_KCP:}
+    kg-inicis: ${PORTONE_CHANNEL_KEY_KG_INICIS:}
+    kakaopay: ${PORTONE_CHANNEL_KEY_KAKAOPAY:}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- issue #261

## #️⃣ 작업 내용

- `devine-api/src/main/resources/application.yml`에서 PortOne 설정 제거
- `devine-core/src/main/resources/core-defaults.yml`로 PortOne 설정 이동

## #️⃣ 테스트 결과

- 로컬 환경에서 PortOne 설정 정상 로드 확인
- API 서버 정상 기동 확인

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

## #️⃣ 리뷰 요구사항 (선택)

## 📎 참고 자료 (선택)

- 멀티모듈 전환 PR: #252
