### PR TITLE
[REFACTOR/API] 개발자 상세, 프로젝트 상세 페이지 dto에 clerk_id 추가

### DIFF
--- a/devine-api/src/main/java/com/umc/devine/domain/member/converter/MemberConverter.java
+++ b/devine-api/src/main/java/com/umc/devine/domain/member/converter/MemberConverter.java
@@ -148,7 +148,7 @@ public class MemberConverter {
             List<MemberCategory> memberCategories,
             List<Contact> contacts
     ) {
-        return toMemberProfileDTO(toOwnerDetailDTO(member), memberCategories, contacts);
+        return toMemberProfileDTO(toOwnerDetailDTO(member), memberCategories, contacts, member.getClerkId());
     }
 
     public static MemberResDTO.MemberProfileDTO toOtherProfileDTO(
@@ -156,13 +156,14 @@ public class MemberConverter {
             List<MemberCategory> memberCategories,
             List<Contact> contacts
     ) {
-        return toMemberProfileDTO(toOtherDetailDTO(member), memberCategories, contacts);
+        return toMemberProfileDTO(toOtherDetailDTO(member), memberCategories, contacts, member.getClerkId());
     }
 
     private static MemberResDTO.MemberProfileDTO toMemberProfileDTO(
             MemberResDTO.MemberDetailDTO memberDTO,
             List<MemberCategory> memberCategories,
-            List<Contact> contacts
+            List<Contact> contacts,
+            String clerkId
     ) {
 
         List<CategoryGenre> domains = memberCategories.stream()
@@ -181,6 +182,7 @@ public class MemberConverter {
                 .member(memberDTO)
                 .domains(domains)
                 .contacts(contactDTOs)
+                .clerkId(clerkId)
                 .build();
     }
 

--- a/devine-api/src/main/java/com/umc/devine/domain/member/dto/MemberResDTO.java
+++ b/devine-api/src/main/java/com/umc/devine/domain/member/dto/MemberResDTO.java
@@ -93,7 +93,9 @@ public class MemberResDTO {
     public record MemberProfileDTO(
             MemberDetailDTO member,
             List<CategoryGenre> domains,
-            List<ContactDTO> contacts
+            List<ContactDTO> contacts,
+            @Schema(description = "Clerk ID (채팅방 생성 시 사용)", example = "user_2abc123xyz")
+            String clerkId
     ){}
 
     @Builder

--- a/devine-api/src/main/java/com/umc/devine/domain/project/converter/ProjectConverter.java
+++ b/devine-api/src/main/java/com/umc/devine/domain/project/converter/ProjectConverter.java
@@ -114,6 +114,7 @@ public class ProjectConverter {
                 .creatorId(project.getMember().getId())
                 .creatorNickname(project.getMember().getNickname())
                 .creatorImage(project.getMember().getImage())
+                .creatorClerkId(project.getMember().getClerkId())
                 .recruitments(toRecruitmentInfoList(project.getRequirements(), techstackMap))
                 .images(toImageInfoList(project.getImages()))
                 .build();

--- a/devine-api/src/main/java/com/umc/devine/domain/project/dto/ProjectResDTO.java
+++ b/devine-api/src/main/java/com/umc/devine/domain/project/dto/ProjectResDTO.java
@@ -132,6 +132,9 @@ public class ProjectResDTO {
             @Schema(description = "프로젝트 생성자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
             String creatorImage,
 
+            @Schema(description = "프로젝트 생성자 Clerk ID (채팅방 생성 시 사용)", example = "user_2abc123xyz")
+            String creatorClerkId,
+
             @Schema(description = "모집 분야 목록")
             List<RecruitmentInfo> recruitments,
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호
- issue #283 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

- 기존 채팅 연결 시 상대방의 clerk_id를 알 수 없어 채팅 연결 불가능
- 개발자 상세 조회 (타인)과 프로젝트 상세 조회(글쓴이)의 clerk_id를 같이 반환
- MemberDetailDTO는 개발자 목록, 추천 개발자 등 다른 응답에서도 재사용되는 공유 DTO라, 여기에 clerkId를 넣으면 의도치 않은 엔드포인트까지 노출되어 clerk_id를  MemberProfileDTO 레벨에 둠
- 

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

### 특정 회원 조회 시 clerk_id 반환
<img width="1426" height="619" alt="image" src="https://github.com/user-attachments/assets/b4df62b3-62b1-4993-be81-2a0455a34c98" />

### 프로젝트 작성자의 clerk_id 반환
<img width="1426" height="619" alt="image" src="https://github.com/user-attachments/assets/e3edb326-3376-4dfa-8e41-035578817c0d" />


## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

- 프로젝트 응답에는 생성자(creator) 관련 정보가 여러 개 묶여 있어서, 일관성 있게 creator 접두어를 붙였습니다.
  멤버 프로필과 달리 프로젝트 상세에서는 "이 프로젝트의 생성자"라는맥락이 필요하다고 생각해서 붙여놨는데 괜찮은거 같은지 의견 부탁드립니다.

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요