### PR TITLE
[FEATURE/API] 토스페이먼츠 외 PG 채널 복구

### DIFF
--- a/devine-api/src/main/java/com/umc/devine/domain/payment/controller/PaymentControllerDocs.java
+++ b/devine-api/src/main/java/com/umc/devine/domain/payment/controller/PaymentControllerDocs.java
@@ -44,7 +44,7 @@ public interface PaymentControllerDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "지원하지 않는 PG사")
     })
     ApiResponse<PaymentResDTO.ChannelKeyDTO> getChannelKey(
-            @Parameter(description = "PG사 (TOSS_PAYMENTS)", example = "TOSS_PAYMENTS")
+            @Parameter(description = "PG사 (NHN_KCP, KG_INICIS, KAKAOPAY, TOSS_PAYMENTS)", example = "TOSS_PAYMENTS")
             @RequestParam PgProvider pg
     );
 }

--- a/devine-api/src/main/java/com/umc/devine/domain/payment/dto/PaymentReqDTO.java
+++ b/devine-api/src/main/java/com/umc/devine/domain/payment/dto/PaymentReqDTO.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -26,6 +27,7 @@ public class PaymentReqDTO {
     @Schema(description = "결제 완료 요청")
     public record CompletePaymentDTO(
             @NotBlank(message = "결제 ID는 필수입니다.")
+            @Size(max = 40, message = "결제 ID는 40자를 초과할 수 없습니다.")
             @Schema(description = "PortOne 결제 ID", example = "payment_1234567890")
             String paymentId,
 

--- a/devine-api/src/main/java/com/umc/devine/domain/payment/service/query/PaymentQueryServiceImpl.java
+++ b/devine-api/src/main/java/com/umc/devine/domain/payment/service/query/PaymentQueryServiceImpl.java
@@ -19,13 +19,22 @@ import java.util.List;
 public class PaymentQueryServiceImpl implements PaymentQueryService {
 
     private final PaymentRepository paymentRepository;
+    private final String nhnKcpChannelKey;
+    private final String kgInicisChannelKey;
+    private final String kakaopayChannelKey;
     private final String tossPaymentsChannelKey;
 
     public PaymentQueryServiceImpl(
             PaymentRepository paymentRepository,
+            @Value("${portone.channel-key.nhn-kcp}") String nhnKcpChannelKey,
+            @Value("${portone.channel-key.kg-inicis}") String kgInicisChannelKey,
+            @Value("${portone.channel-key.kakaopay}") String kakaopayChannelKey,
             @Value("${portone.channel-key.toss-payments}") String tossPaymentsChannelKey
     ) {
         this.paymentRepository = paymentRepository;
+        this.nhnKcpChannelKey = nhnKcpChannelKey;
+        this.kgInicisChannelKey = kgInicisChannelKey;
+        this.kakaopayChannelKey = kakaopayChannelKey;
         this.tossPaymentsChannelKey = tossPaymentsChannelKey;
     }
 
@@ -38,6 +47,9 @@ public class PaymentQueryServiceImpl implements PaymentQueryService {
     @Override
     public PaymentResDTO.ChannelKeyDTO getChannelKey(PgProvider pgProvider) {
         String channelKey = switch (pgProvider) {
+            case NHN_KCP -> nhnKcpChannelKey;
+            case KG_INICIS -> kgInicisChannelKey;
+            case KAKAOPAY -> kakaopayChannelKey;
             case TOSS_PAYMENTS -> tossPaymentsChannelKey;
         };
         if (channelKey == null || channelKey.isBlank()) {

--- a/devine-api/src/main/resources/application.yml
+++ b/devine-api/src/main/resources/application.yml
@@ -55,4 +55,7 @@ portone:
   base-url: https://api.portone.io
   webhook-secret: ${PORTONE_WEBHOOK_SECRET:}
   channel-key:
+    nhn-kcp: ${PORTONE_CHANNEL_KEY_NHN_KCP:}
+    kg-inicis: ${PORTONE_CHANNEL_KEY_KG_INICIS:}
+    kakaopay: ${PORTONE_CHANNEL_KEY_KAKAOPAY:}
     toss-payments: ${PORTONE_CHANNEL_KEY_TOSS_PAYMENTS:}

--- a/devine-core/src/main/java/com/umc/devine/domain/payment/enums/PgProvider.java
+++ b/devine-core/src/main/java/com/umc/devine/domain/payment/enums/PgProvider.java
@@ -1,5 +1,8 @@
 package com.umc.devine.domain.payment.enums;
 
 public enum PgProvider {
+    NHN_KCP,
+    KG_INICIS,
+    KAKAOPAY,
     TOSS_PAYMENTS
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호
- issue #291 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

#289에서 제거했던 NHN KCP, KG이니시스, 카카오페이 관련 `PgProvider` enum 값, 환경변수, 분기 로직을 복구했습니다. 실서비스에서는 아직 토스페이먼츠 채널키만 존재하므로, 나머지 PG사의 env 값이 비어 있어도 서버 기동에는 영향이 없고 조회 시 `UNSUPPORTED_PAYMENT_METHOD` 예외로 안전하게 처리됩니다.

- `PgProvider` enum에 `NHN_KCP`, `KG_INICIS`, `KAKAOPAY` 복구
- `application.yml`의 `channel-key`에 제거됐던 PG사 항목 복구 (`${VAR:}` 빈 기본값 문법 유지)
- `PaymentQueryServiceImpl` 생성자 파라미터 및 채널키 조회 `switch` 분기 복구
- `PaymentControllerDocs` Swagger 파라미터 설명/예시 갱신
- NHN KCP, KG이니시스는 `oid`(merchant_uid) 길이 제한이 40자라 `CompletePaymentDTO.paymentId`에 `@Size(max = 40)` 검증 추가 (조기 방어용, 근본 해결은 프론트 `paymentId` 생성 규칙 수정 필요)

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요