### PR TITLE
[FEATURE/API] 관리자 로그인 인증/인가 골격

### DIFF
--- a/devine-api/src/main/java/com/umc/devine/admin/auth/controller/AdminAuthController.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/controller/AdminAuthController.java
@@ -1,0 +1,29 @@
+package com.umc.devine.admin.auth.controller;
+
+import com.umc.devine.admin.auth.dto.AdminAuthResDTO;
+import com.umc.devine.admin.auth.exception.code.AdminAuthSuccessCode;
+import com.umc.devine.admin.auth.security.AdminPrincipal;
+import com.umc.devine.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/v1/auth")
+public class AdminAuthController implements AdminAuthControllerDocs {
+
+    @Override
+    @GetMapping("/me")
+    public ApiResponse<AdminAuthResDTO.MeDTO> me(@AuthenticationPrincipal AdminPrincipal principal) {
+        AdminAuthResDTO.MeDTO response = AdminAuthResDTO.MeDTO.builder()
+                .clerkId(principal.getClerkId())
+                .email(principal.getEmail())
+                .level(principal.getLevel())
+                .build();
+
+        return ApiResponse.onSuccess(AdminAuthSuccessCode.ADMIN_ME_OK, response);
+    }
+}

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/controller/AdminAuthControllerDocs.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/controller/AdminAuthControllerDocs.java
@@ -1,0 +1,22 @@
+package com.umc.devine.admin.auth.controller;
+
+import com.umc.devine.admin.auth.dto.AdminAuthResDTO;
+import com.umc.devine.admin.auth.security.AdminPrincipal;
+import com.umc.devine.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "Admin Auth", description = "관리자 인증 관련 API")
+public interface AdminAuthControllerDocs {
+
+    @Operation(summary = "관리자 내 정보 조회 API",
+            description = "현재 로그인한 관리자의 정보(권한 레벨 포함)를 조회합니다. Clerk 토큰 기반이며 ROLE_ADMIN이 필요합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 없습니다.")
+    })
+    ApiResponse<AdminAuthResDTO.MeDTO> me(@AuthenticationPrincipal AdminPrincipal principal);
+}

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/dto/AdminAuthResDTO.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/dto/AdminAuthResDTO.java
@@ -1,0 +1,20 @@
+package com.umc.devine.admin.auth.dto;
+
+import com.umc.devine.admin.enums.AdminLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AdminAuthResDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MeDTO {
+        private String clerkId;
+        private String email;
+        private AdminLevel level;
+    }
+}

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/exception/code/AdminAuthSuccessCode.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/exception/code/AdminAuthSuccessCode.java
@@ -1,0 +1,20 @@
+package com.umc.devine.admin.auth.exception.code;
+
+import com.umc.devine.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AdminAuthSuccessCode implements BaseSuccessCode {
+
+    ADMIN_ME_OK(HttpStatus.OK,
+            "ADMIN_AUTH200_1",
+            "관리자 정보를 성공적으로 조회했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminAccessDeniedHandler.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminAccessDeniedHandler.java
@@ -1,0 +1,51 @@
+package com.umc.devine.admin.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.devine.global.exception.GeneralErrorReason;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * 관리자 체인에서 권한 없는 접근(403)을 처리한다.
+ * 접근을 감사 로그로 남기고, 관리자 존재 여부를 노출하지 않는 일반 메시지를 응답한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class AdminAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final AdminAccessLogger adminAccessLogger;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        String clerkId = AdminAccessLogger.clerkIdOf(SecurityContextHolder.getContext().getAuthentication());
+        adminAccessLogger.logDenied(clerkId, request.getMethod(), request.getRequestURI(),
+                HttpStatus.FORBIDDEN.value());
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        Map<String, Object> body = Map.of(
+                "isSuccess", false,
+                "code", GeneralErrorReason.FORBIDDEN.getCode(),
+                "message", GeneralErrorReason.FORBIDDEN.getMessage()
+        );
+
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminAccessLogger.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminAccessLogger.java
@@ -1,0 +1,43 @@
+package com.umc.devine.admin.auth.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * 관리자 접근 감사 로그.
+ * 별도 DB 감사 테이블 없이 구조화 로그로만 관리자 접근/거절을 남긴다.
+ * (되돌릴 수 없는 관리자 변경 기능이 도입되면 그때 DB 감사 테이블을 검토한다.)
+ */
+@Slf4j
+@Component
+public class AdminAccessLogger {
+
+    /** 인가된 관리자 접근 기록 */
+    public void logAccess(String clerkId, String method, String path, int status) {
+        log.info("[ADMIN-ACCESS] clerkId={} method={} path={} status={}",
+                clerkIdOrAnonymous(clerkId), method, path, status);
+    }
+
+    /** 권한 없는 접근(403) 기록 */
+    public void logDenied(String clerkId, String method, String path, int status) {
+        log.warn("[ADMIN-ACCESS-DENIED] clerkId={} method={} path={} status={}",
+                clerkIdOrAnonymous(clerkId), method, path, status);
+    }
+
+    private String clerkIdOrAnonymous(String clerkId) {
+        return clerkId == null ? "anonymous" : clerkId;
+    }
+
+    /** SecurityContext의 인증 주체에서 clerkId를 추출한다. */
+    public static String clerkIdOf(Authentication authentication) {
+        if (authentication == null) {
+            return null;
+        }
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof AdminPrincipal adminPrincipal) {
+            return adminPrincipal.getClerkId();
+        }
+        return authentication.getName();
+    }
+}

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminAccessLoggingFilter.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminAccessLoggingFilter.java
@@ -1,0 +1,36 @@
+package com.umc.devine.admin.auth.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * 인가된 관리자 요청을 감사 로그로 남기는 필터.
+ *
+ * <p>관리자 체인의 AuthorizationFilter 뒤에 배치되어, 인가를 통과한 요청만 처리한다.
+ * (권한 없는 접근은 {@link AdminAccessDeniedHandler}가 별도로 기록한다.)
+ * 컴포넌트로 등록하면 서블릿 전역 필터로 자동 등록되므로, 관리자 체인에서만 수동으로 추가한다.
+ */
+@RequiredArgsConstructor
+public class AdminAccessLoggingFilter extends OncePerRequestFilter {
+
+    private final AdminAccessLogger adminAccessLogger;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            String clerkId = AdminAccessLogger.clerkIdOf(SecurityContextHolder.getContext().getAuthentication());
+            adminAccessLogger.logAccess(clerkId, request.getMethod(), request.getRequestURI(), response.getStatus());
+        }
+    }
+}

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminJwtAuthenticationConverter.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminJwtAuthenticationConverter.java
@@ -37,6 +37,7 @@ public class AdminJwtAuthenticationConverter implements Converter<Jwt, AbstractA
         String name = jwt.getClaimAsString("name");
         String imageUrl = jwt.getClaimAsString("image_url");
 
+        // 판정은 clerk_id(sub)만 신뢰한다. email은 표시/저장용으로만 넘긴다.
         Optional<Admin> admin = adminAuthorizationService.resolveAdmin(clerkId, email);
 
         AdminPrincipal principal = AdminPrincipal.builder()

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminJwtAuthenticationConverter.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminJwtAuthenticationConverter.java
@@ -1,0 +1,61 @@
+package com.umc.devine.admin.auth.security;
+
+import com.umc.devine.admin.auth.service.AdminAuthorizationService;
+import com.umc.devine.admin.entity.Admin;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 관리자 전용 SecurityFilterChain(/admin/**)에서만 사용하는 JWT 변환기.
+ *
+ * <p>Clerk JWT를 검증한 뒤, {@link AdminAuthorizationService}로 관리자 여부를 판정한다.
+ * 관리자면 {@code ROLE_ADMIN}을 부여하고 {@link AdminPrincipal}을 주체로 세팅한다.
+ * 관리자가 아니면 권한을 부여하지 않아, 인가 단계({@code hasRole("ADMIN")})에서 403으로 거절된다.
+ */
+@Component
+@RequiredArgsConstructor
+public class AdminJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    private static final String ROLE_ADMIN = "ROLE_ADMIN";
+
+    private final AdminAuthorizationService adminAuthorizationService;
+
+    @Override
+    public AbstractAuthenticationToken convert(Jwt jwt) {
+        String clerkId = jwt.getSubject();
+        String email = jwt.getClaimAsString("email");
+        String name = jwt.getClaimAsString("name");
+        String imageUrl = jwt.getClaimAsString("image_url");
+
+        Optional<Admin> admin = adminAuthorizationService.resolveAdmin(clerkId, email);
+
+        AdminPrincipal principal = AdminPrincipal.builder()
+                .clerkId(clerkId)
+                .email(email)
+                .name(name)
+                .imageUrl(imageUrl)
+                .level(admin.map(Admin::getLevel).orElse(null))
+                .build();
+
+        List<GrantedAuthority> authorities = admin.isPresent()
+                ? List.of(new SimpleGrantedAuthority(ROLE_ADMIN))
+                : Collections.emptyList();
+
+        return new JwtAuthenticationToken(jwt, authorities, principal.getName()) {
+            @Override
+            public Object getPrincipal() {
+                return principal;
+            }
+        };
+    }
+}

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminPrincipal.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/security/AdminPrincipal.java
@@ -1,0 +1,34 @@
+package com.umc.devine.admin.auth.security;
+
+import com.umc.devine.admin.enums.AdminLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.security.Principal;
+
+/**
+ * 관리자 인증 주체.
+ * Clerk JWT의 신원 정보(clerkId/email/...)에 더해, admin 테이블에서 확인된 권한 레벨을 담는다.
+ * {@code @AuthenticationPrincipal AdminPrincipal}로 관리자 엔드포인트에서 주입받는다.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class AdminPrincipal implements Principal {
+
+    private final String clerkId;
+    private final String email;
+    private final String name;
+    private final String imageUrl;
+    private final AdminLevel level;
+
+    @Override
+    public String getName() {
+        return clerkId;
+    }
+
+    public String getFullName() {
+        return name;
+    }
+}

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/service/AdminAuthorizationService.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/service/AdminAuthorizationService.java
@@ -1,11 +1,9 @@
 package com.umc.devine.admin.auth.service;
 
 import com.umc.devine.admin.entity.Admin;
-import com.umc.devine.admin.enums.AdminLevel;
 import com.umc.devine.admin.repository.AdminRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -21,7 +19,8 @@ import java.util.stream.Collectors;
  *
  * <p>판정 순서:
  * <ol>
- *   <li>admin 테이블에 활성 관리자로 존재하면 그대로 사용</li>
+ *   <li>admin 테이블에 (활성 여부 무관) 존재하면 그 행의 활성 상태를 따른다.
+ *       비활성(회수)이면 관리자가 아니다 — 부트스트랩 목록에 남아 있어도 회수를 우선한다.</li>
  *   <li>없지만 이메일이 부트스트랩 목록에 있으면, admin 테이블에 자동 등록(lazy seeding) 후 사용</li>
  *   <li>둘 다 아니면 관리자가 아님(빈 결과)</li>
  * </ol>
@@ -44,46 +43,46 @@ public class AdminAuthorizationService {
     }
 
     /**
-     * clerkId/email로 활성 관리자를 조회한다. 부트스트랩 이메일이면 최초 접근 시 자동 등록한다.
+     * clerkId/email로 관리자를 판정한다. 부트스트랩 이메일이면 최초 접근 시 자동 등록한다.
      *
-     * @return 관리자면 해당 Admin, 아니면 빈 Optional
+     * @return 활성 관리자면 해당 Admin, 아니면 빈 Optional
      */
     @Transactional
     public Optional<Admin> resolveAdmin(String clerkId, String email) {
-        Optional<Admin> existing = adminRepository.findActiveByClerkId(clerkId);
-        if (existing.isPresent()) {
-            return existing;
+        // 회수 우선: clerk_id 행이 있으면(활성 여부 무관) 그 활성 상태를 따른다.
+        Optional<Admin> byClerkId = adminRepository.findByClerkId(clerkId);
+        if (byClerkId.isPresent()) {
+            return activeOrEmpty(byClerkId.get());
         }
 
-        if (email == null || !bootstrapEmails.contains(normalize(email))) {
+        String normalizedEmail = normalize(email);
+        if (normalizedEmail == null || !bootstrapEmails.contains(normalizedEmail)) {
             return Optional.empty();
         }
 
-        return Optional.of(seedBootstrapAdmin(clerkId, email));
+        // 같은 이메일의 기존 행이 있으면(비활성 회수 포함) 그 활성 상태를 따른다 → 비활성이면 재등록하지 않는다.
+        Optional<Admin> byEmail = adminRepository.findByEmail(normalizedEmail);
+        if (byEmail.isPresent()) {
+            return activeOrEmpty(byEmail.get());
+        }
+
+        return seedBootstrapAdmin(clerkId, normalizedEmail);
     }
 
-    private Admin seedBootstrapAdmin(String clerkId, String email) {
-        // 이미 이 이메일로 등록된 관리자가 있으면 재사용(다른 clerkId로 등록된 예외적 상황 포함)
-        Optional<Admin> byEmail = adminRepository.findActiveByEmail(normalize(email));
-        if (byEmail.isPresent()) {
-            return byEmail.get();
-        }
+    private Optional<Admin> seedBootstrapAdmin(String clerkId, String normalizedEmail) {
+        // ON CONFLICT DO NOTHING: 동시 최초 접근/재진입에도 예외 없이 멱등하게 처리(트랜잭션 abort 차단).
+        adminRepository.insertBootstrapAdminIfAbsent(clerkId, normalizedEmail, BOOTSTRAP_GRANTED_BY);
 
-        try {
-            Admin created = adminRepository.save(Admin.builder()
-                    .clerkId(clerkId)
-                    .email(normalize(email))
-                    .level(AdminLevel.ADMIN)
-                    .grantedBy(BOOTSTRAP_GRANTED_BY)
-                    .build());
-            log.info("[ADMIN] bootstrap 관리자 자동 등록 clerkId={} email={}", clerkId, normalize(email));
-            return created;
-        } catch (DataIntegrityViolationException e) {
-            // 동시 최초 접근으로 이미 등록된 경우: 재조회하여 그 결과를 사용
-            return adminRepository.findActiveByClerkId(clerkId)
-                    .or(() -> adminRepository.findActiveByEmail(normalize(email)))
-                    .orElseThrow(() -> e);
-        }
+        // DO NOTHING은 행을 반환하지 않으므로 후속 SELECT.
+        // 경합으로 email 충돌이 났다면 clerk_id로는 안 나오므로 email로 폴백하고, 그 결과에도 활성 판정을 적용한다.
+        Optional<Admin> seeded = adminRepository.findByClerkId(clerkId)
+                .or(() -> adminRepository.findByEmail(normalizedEmail));
+        seeded.ifPresent(a -> log.info("[ADMIN] bootstrap 관리자 등록/확인 clerkId={} email={}", clerkId, normalizedEmail));
+        return seeded.flatMap(this::activeOrEmpty);
+    }
+
+    private Optional<Admin> activeOrEmpty(Admin admin) {
+        return admin.isActive() ? Optional.of(admin) : Optional.empty();
     }
 
     private Set<String> parseEmails(String raw) {

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/service/AdminAuthorizationService.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/service/AdminAuthorizationService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -17,11 +16,14 @@ import java.util.stream.Collectors;
 /**
  * "누가 관리자인가"를 판정하는 서비스.
  *
+ * <p>판정은 오직 {@code clerk_id}(JWT의 sub, 위조 불가)만 신뢰한다. 이메일/이메일 검증 같은
+ * Clerk 클레임 의미론에 권한 경계를 의존시키지 않는다.
+ *
  * <p>판정 순서:
  * <ol>
  *   <li>admin 테이블에 (활성 여부 무관) 존재하면 그 행의 활성 상태를 따른다.
  *       비활성(회수)이면 관리자가 아니다 — 부트스트랩 목록에 남아 있어도 회수를 우선한다.</li>
- *   <li>없지만 이메일이 부트스트랩 목록에 있으면, admin 테이블에 자동 등록(lazy seeding) 후 사용</li>
+ *   <li>없지만 clerk_id가 부트스트랩 목록에 있으면, admin 테이블에 자동 등록(lazy seeding) 후 사용</li>
  *   <li>둘 다 아니면 관리자가 아님(빈 결과)</li>
  * </ol>
  *
@@ -34,17 +36,18 @@ public class AdminAuthorizationService {
     private static final String BOOTSTRAP_GRANTED_BY = "BOOTSTRAP";
 
     private final AdminRepository adminRepository;
-    private final Set<String> bootstrapEmails;
+    private final Set<String> bootstrapClerkIds;
 
     public AdminAuthorizationService(AdminRepository adminRepository,
-                                     @Value("${admin.bootstrap-emails:}") String bootstrapEmailsRaw) {
+                                     @Value("${admin.bootstrap-clerk-ids:}") String bootstrapClerkIdsRaw) {
         this.adminRepository = adminRepository;
-        this.bootstrapEmails = parseEmails(bootstrapEmailsRaw);
+        this.bootstrapClerkIds = parseClerkIds(bootstrapClerkIdsRaw);
     }
 
     /**
-     * clerkId/email로 관리자를 판정한다. 부트스트랩 이메일이면 최초 접근 시 자동 등록한다.
+     * clerkId로 관리자를 판정한다. 부트스트랩 clerk_id면 최초 접근 시 자동 등록한다.
      *
+     * @param email JWT의 email 클레임(있으면 표시/감사용으로 저장, 없으면 null). 판정에는 쓰이지 않는다.
      * @return 활성 관리자면 해당 Admin, 아니면 빈 Optional
      */
     @Transactional
@@ -55,29 +58,21 @@ public class AdminAuthorizationService {
             return activeOrEmpty(byClerkId.get());
         }
 
-        String normalizedEmail = normalize(email);
-        if (normalizedEmail == null || !bootstrapEmails.contains(normalizedEmail)) {
+        // 부트스트랩은 clerk_id(sub)만 신뢰한다.
+        if (clerkId == null || !bootstrapClerkIds.contains(clerkId)) {
             return Optional.empty();
         }
 
-        // 같은 이메일의 기존 행이 있으면(비활성 회수 포함) 그 활성 상태를 따른다 → 비활성이면 재등록하지 않는다.
-        Optional<Admin> byEmail = adminRepository.findByEmail(normalizedEmail);
-        if (byEmail.isPresent()) {
-            return activeOrEmpty(byEmail.get());
-        }
-
-        return seedBootstrapAdmin(clerkId, normalizedEmail);
+        return seedBootstrapAdmin(clerkId, email);
     }
 
-    private Optional<Admin> seedBootstrapAdmin(String clerkId, String normalizedEmail) {
+    private Optional<Admin> seedBootstrapAdmin(String clerkId, String email) {
         // ON CONFLICT DO NOTHING: 동시 최초 접근/재진입에도 예외 없이 멱등하게 처리(트랜잭션 abort 차단).
-        adminRepository.insertBootstrapAdminIfAbsent(clerkId, normalizedEmail, BOOTSTRAP_GRANTED_BY);
+        adminRepository.insertBootstrapAdminIfAbsent(clerkId, normalizeEmail(email), BOOTSTRAP_GRANTED_BY);
 
-        // DO NOTHING은 행을 반환하지 않으므로 후속 SELECT.
-        // 경합으로 email 충돌이 났다면 clerk_id로는 안 나오므로 email로 폴백하고, 그 결과에도 활성 판정을 적용한다.
-        Optional<Admin> seeded = adminRepository.findByClerkId(clerkId)
-                .or(() -> adminRepository.findByEmail(normalizedEmail));
-        seeded.ifPresent(a -> log.info("[ADMIN] bootstrap 관리자 등록/확인 clerkId={} email={}", clerkId, normalizedEmail));
+        // DO NOTHING은 행을 반환하지 않으므로 후속 SELECT로 확인한다.
+        Optional<Admin> seeded = adminRepository.findByClerkId(clerkId);
+        seeded.ifPresent(a -> log.info("[ADMIN] bootstrap 관리자 등록/확인 clerkId={}", clerkId));
         return seeded.flatMap(this::activeOrEmpty);
     }
 
@@ -85,17 +80,17 @@ public class AdminAuthorizationService {
         return admin.isActive() ? Optional.of(admin) : Optional.empty();
     }
 
-    private Set<String> parseEmails(String raw) {
+    private Set<String> parseClerkIds(String raw) {
         if (!StringUtils.hasText(raw)) {
             return Set.of();
         }
         return Arrays.stream(raw.split(","))
-                .map(this::normalize)
+                .map(String::trim)
                 .filter(StringUtils::hasText)
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    private String normalize(String email) {
-        return email == null ? null : email.trim().toLowerCase(Locale.ROOT);
+    private String normalizeEmail(String email) {
+        return StringUtils.hasText(email) ? email.trim().toLowerCase(java.util.Locale.ROOT) : null;
     }
 }

--- a/devine-api/src/main/java/com/umc/devine/admin/auth/service/AdminAuthorizationService.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/auth/service/AdminAuthorizationService.java
@@ -1,0 +1,102 @@
+package com.umc.devine.admin.auth.service;
+
+import com.umc.devine.admin.entity.Admin;
+import com.umc.devine.admin.enums.AdminLevel;
+import com.umc.devine.admin.repository.AdminRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * "누가 관리자인가"를 판정하는 서비스.
+ *
+ * <p>판정 순서:
+ * <ol>
+ *   <li>admin 테이블에 활성 관리자로 존재하면 그대로 사용</li>
+ *   <li>없지만 이메일이 부트스트랩 목록에 있으면, admin 테이블에 자동 등록(lazy seeding) 후 사용</li>
+ *   <li>둘 다 아니면 관리자가 아님(빈 결과)</li>
+ * </ol>
+ *
+ * <p>이 로직을 시큐리티 계층에서 분리해, converter가 트랜잭션 경계 안에서 이 서비스에만 위임하도록 한다.
+ */
+@Slf4j
+@Service
+public class AdminAuthorizationService {
+
+    private static final String BOOTSTRAP_GRANTED_BY = "BOOTSTRAP";
+
+    private final AdminRepository adminRepository;
+    private final Set<String> bootstrapEmails;
+
+    public AdminAuthorizationService(AdminRepository adminRepository,
+                                     @Value("${admin.bootstrap-emails:}") String bootstrapEmailsRaw) {
+        this.adminRepository = adminRepository;
+        this.bootstrapEmails = parseEmails(bootstrapEmailsRaw);
+    }
+
+    /**
+     * clerkId/email로 활성 관리자를 조회한다. 부트스트랩 이메일이면 최초 접근 시 자동 등록한다.
+     *
+     * @return 관리자면 해당 Admin, 아니면 빈 Optional
+     */
+    @Transactional
+    public Optional<Admin> resolveAdmin(String clerkId, String email) {
+        Optional<Admin> existing = adminRepository.findActiveByClerkId(clerkId);
+        if (existing.isPresent()) {
+            return existing;
+        }
+
+        if (email == null || !bootstrapEmails.contains(normalize(email))) {
+            return Optional.empty();
+        }
+
+        return Optional.of(seedBootstrapAdmin(clerkId, email));
+    }
+
+    private Admin seedBootstrapAdmin(String clerkId, String email) {
+        // 이미 이 이메일로 등록된 관리자가 있으면 재사용(다른 clerkId로 등록된 예외적 상황 포함)
+        Optional<Admin> byEmail = adminRepository.findActiveByEmail(normalize(email));
+        if (byEmail.isPresent()) {
+            return byEmail.get();
+        }
+
+        try {
+            Admin created = adminRepository.save(Admin.builder()
+                    .clerkId(clerkId)
+                    .email(normalize(email))
+                    .level(AdminLevel.ADMIN)
+                    .grantedBy(BOOTSTRAP_GRANTED_BY)
+                    .build());
+            log.info("[ADMIN] bootstrap 관리자 자동 등록 clerkId={} email={}", clerkId, normalize(email));
+            return created;
+        } catch (DataIntegrityViolationException e) {
+            // 동시 최초 접근으로 이미 등록된 경우: 재조회하여 그 결과를 사용
+            return adminRepository.findActiveByClerkId(clerkId)
+                    .or(() -> adminRepository.findActiveByEmail(normalize(email)))
+                    .orElseThrow(() -> e);
+        }
+    }
+
+    private Set<String> parseEmails(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return Set.of();
+        }
+        return Arrays.stream(raw.split(","))
+                .map(this::normalize)
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private String normalize(String email) {
+        return email == null ? null : email.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/devine-api/src/main/java/com/umc/devine/global/config/ApiSecurityConfig.java
+++ b/devine-api/src/main/java/com/umc/devine/global/config/ApiSecurityConfig.java
@@ -1,11 +1,13 @@
 package com.umc.devine.global.config;
 
+import com.umc.devine.admin.auth.security.AdminJwtAuthenticationConverter;
 import com.umc.devine.global.security.ClerkJwtAuthenticationConverter;
 import com.umc.devine.global.security.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -25,12 +27,40 @@ import java.util.List;
 public class ApiSecurityConfig {
 
     private final ClerkJwtAuthenticationConverter clerkJwtAuthenticationConverter;
+    private final AdminJwtAuthenticationConverter adminJwtAuthenticationConverter;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Value("${cors.allowed-origins}")
     private String allowedOrigins;
 
+    /**
+     * 관리자 전용 체인. /admin/** 경로만 담당하며 ROLE_ADMIN을 요구한다.
+     * 일반 유저와 동일한 Clerk JWT로 인증하되, 인가(관리자 판정)만 분리한다.
+     */
     @Bean
+    @Order(1)
+    public SecurityFilterChain adminSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher("/admin/**")
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().hasRole("ADMIN")
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(adminJwtAuthenticationConverter))
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                )
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))

--- a/devine-api/src/main/java/com/umc/devine/global/config/ApiSecurityConfig.java
+++ b/devine-api/src/main/java/com/umc/devine/global/config/ApiSecurityConfig.java
@@ -1,5 +1,8 @@
 package com.umc.devine.global.config;
 
+import com.umc.devine.admin.auth.security.AdminAccessDeniedHandler;
+import com.umc.devine.admin.auth.security.AdminAccessLogger;
+import com.umc.devine.admin.auth.security.AdminAccessLoggingFilter;
 import com.umc.devine.admin.auth.security.AdminJwtAuthenticationConverter;
 import com.umc.devine.global.security.ClerkJwtAuthenticationConverter;
 import com.umc.devine.global.security.CustomAuthenticationEntryPoint;
@@ -14,6 +17,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -28,6 +32,8 @@ public class ApiSecurityConfig {
 
     private final ClerkJwtAuthenticationConverter clerkJwtAuthenticationConverter;
     private final AdminJwtAuthenticationConverter adminJwtAuthenticationConverter;
+    private final AdminAccessDeniedHandler adminAccessDeniedHandler;
+    private final AdminAccessLogger adminAccessLogger;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Value("${cors.allowed-origins}")
@@ -54,6 +60,9 @@ public class ApiSecurityConfig {
                         .jwt(jwt -> jwt.jwtAuthenticationConverter(adminJwtAuthenticationConverter))
                         .authenticationEntryPoint(customAuthenticationEntryPoint)
                 )
+                .exceptionHandling(ex -> ex.accessDeniedHandler(adminAccessDeniedHandler))
+                // 인가를 통과한 관리자 요청을 감사 로그로 남긴다 (거절은 AdminAccessDeniedHandler가 기록)
+                .addFilterAfter(new AdminAccessLoggingFilter(adminAccessLogger), AuthorizationFilter.class)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .build();

--- a/devine-api/src/main/resources/application.yml
+++ b/devine-api/src/main/resources/application.yml
@@ -50,6 +50,8 @@ cors:
 
 # Admin (관리자 인증/인가)
 # bootstrap-emails: 최초 관리자 부트스트랩용 이메일 목록(콤마 구분). 이 이메일로 처음 /admin 접근 시 admin 테이블에 자동 등록된다.
+#   운영 주의: 관리자를 회수(is_active=false)할 때는 이 목록에서도 해당 이메일을 반드시 제거해야 한다.
+#   목록에 남아 있어도 회수 우선 정책상 재활성화되지는 않지만, 목록 정리가 부트스트랩 백도어를 최소화한다.
 admin:
   bootstrap-emails: ${ADMIN_BOOTSTRAP_EMAILS:}
 

--- a/devine-api/src/main/resources/application.yml
+++ b/devine-api/src/main/resources/application.yml
@@ -48,6 +48,11 @@ github:
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
 
+# Admin (관리자 인증/인가)
+# bootstrap-emails: 최초 관리자 부트스트랩용 이메일 목록(콤마 구분). 이 이메일로 처음 /admin 접근 시 admin 테이블에 자동 등록된다.
+admin:
+  bootstrap-emails: ${ADMIN_BOOTSTRAP_EMAILS:}
+
 # PortOne
 portone:
   store-id: ${PORTONE_STORE_ID:}

--- a/devine-api/src/main/resources/application.yml
+++ b/devine-api/src/main/resources/application.yml
@@ -49,11 +49,14 @@ cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
 
 # Admin (관리자 인증/인가)
-# bootstrap-emails: 최초 관리자 부트스트랩용 이메일 목록(콤마 구분). 이 이메일로 처음 /admin 접근 시 admin 테이블에 자동 등록된다.
-#   운영 주의: 관리자를 회수(is_active=false)할 때는 이 목록에서도 해당 이메일을 반드시 제거해야 한다.
-#   목록에 남아 있어도 회수 우선 정책상 재활성화되지는 않지만, 목록 정리가 부트스트랩 백도어를 최소화한다.
+# bootstrap-clerk-ids: 최초 관리자 부트스트랩용 Clerk user id(user_xxx) 목록(콤마 구분).
+#   이 clerk_id로 처음 /admin 접근 시 admin 테이블에 자동 등록된다.
+#   판정은 clerk_id(sub, 위조 불가)만 신뢰하므로 Clerk 세션 토큰 커스터마이즈(email 등)는 관리자용으론 불필요하다.
+#   최초 관리자의 user id 확보: 로그인 후 /admin 접근 시 403 감사 로그의 clerkId, 또는 Clerk Dashboard → Users → User ID.
+#   운영 주의(회수): 관리자를 회수(is_active=false)할 때는 이 목록에서도 해당 clerk_id를 반드시 제거한다.
+#     목록에 남아 있어도 회수 우선 정책상 재활성화되지는 않지만, 목록 정리가 부트스트랩 백도어를 최소화한다.
 admin:
-  bootstrap-emails: ${ADMIN_BOOTSTRAP_EMAILS:}
+  bootstrap-clerk-ids: ${ADMIN_BOOTSTRAP_CLERK_IDS:}
 
 # PortOne
 portone:

--- a/devine-api/src/test/java/com/umc/devine/admin/auth/controller/AdminAuthControllerTest.java
+++ b/devine-api/src/test/java/com/umc/devine/admin/auth/controller/AdminAuthControllerTest.java
@@ -1,0 +1,70 @@
+package com.umc.devine.admin.auth.controller;
+
+import com.umc.devine.admin.auth.security.AdminPrincipal;
+import com.umc.devine.admin.enums.AdminLevel;
+import com.umc.devine.global.security.ClerkPrincipal;
+import com.umc.devine.support.ControllerIntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AdminAuthControllerTest extends ControllerIntegrationTestSupport {
+
+    private Authentication adminAuth() {
+        AdminPrincipal principal = AdminPrincipal.builder()
+                .clerkId("admin_clerk_1")
+                .email("admin@devine.com")
+                .name("관리자")
+                .level(AdminLevel.ADMIN)
+                .build();
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+    }
+
+    private Authentication nonAdminAuth() {
+        ClerkPrincipal principal = new ClerkPrincipal("user_clerk_1", "user@devine.com", "유저", null);
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, Collections.emptyList());
+    }
+
+    @Test
+    @DisplayName("관리자는 /admin/v1/auth/me에서 자신의 정보(권한 레벨 포함)를 조회한다")
+    void me_success_for_admin() throws Exception {
+        mockMvc.perform(get("/admin/v1/auth/me")
+                        .with(authentication(adminAuth()))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.clerkId").value("admin_clerk_1"))
+                .andExpect(jsonPath("$.result.email").value("admin@devine.com"))
+                .andExpect(jsonPath("$.result.level").value("ADMIN"));
+    }
+
+    @Test
+    @DisplayName("ROLE_ADMIN이 없는 사용자는 403으로 거절된다")
+    void me_forbidden_for_non_admin() throws Exception {
+        mockMvc.perform(get("/admin/v1/auth/me")
+                        .with(authentication(nonAdminAuth()))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("인증 없이 접근하면 401로 거절된다")
+    void me_unauthorized_without_authentication() throws Exception {
+        mockMvc.perform(get("/admin/v1/auth/me")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/devine-api/src/test/java/com/umc/devine/admin/auth/controller/AdminAuthControllerTest.java
+++ b/devine-api/src/test/java/com/umc/devine/admin/auth/controller/AdminAuthControllerTest.java
@@ -52,12 +52,14 @@ class AdminAuthControllerTest extends ControllerIntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("ROLE_ADMIN이 없는 사용자는 403으로 거절된다")
+    @DisplayName("ROLE_ADMIN이 없는 사용자는 403과 일반 오류 메시지로 거절된다 (관리자 존재 비노출)")
     void me_forbidden_for_non_admin() throws Exception {
         mockMvc.perform(get("/admin/v1/auth/me")
                         .with(authentication(nonAdminAuth()))
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("AUTH403_1"));
     }
 
     @Test

--- a/devine-api/src/test/java/com/umc/devine/admin/auth/service/AdminAuthorizationServiceIntegrationTest.java
+++ b/devine-api/src/test/java/com/umc/devine/admin/auth/service/AdminAuthorizationServiceIntegrationTest.java
@@ -16,9 +16,9 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * 실제 Postgres에 대해 AdminAuthorizationService의 seeding/회수 동작을 검증한다.
- * (네이티브 ON CONFLICT upsert가 실제 스키마에서 동작하는지, 회수된 부트스트랩 관리자가 500 없이 거절되는지)
+ * (네이티브 ON CONFLICT upsert가 실제 스키마에서 동작하는지, 회수된 관리자가 500 없이 거절되는지)
  */
-@TestPropertySource(properties = "admin.bootstrap-emails=boot@devine.com,revoked@devine.com")
+@TestPropertySource(properties = "admin.bootstrap-clerk-ids=user_boot,user_revoked")
 class AdminAuthorizationServiceIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
@@ -28,50 +28,57 @@ class AdminAuthorizationServiceIntegrationTest extends IntegrationTestSupport {
     private AdminRepository adminRepository;
 
     @Test
-    @DisplayName("부트스트랩 이메일로 최초 접근하면 admin 테이블에 자동 등록되고 활성 관리자로 반환된다")
+    @DisplayName("부트스트랩 clerk_id로 최초 접근하면 admin 테이블에 자동 등록되고 활성 관리자로 반환된다")
     void bootstrap_seeds_admin() {
-        Optional<Admin> result = adminAuthorizationService.resolveAdmin("clerk_fresh", "boot@devine.com");
+        Optional<Admin> result = adminAuthorizationService.resolveAdmin("user_boot", "boot@devine.com");
 
         assertThat(result).isPresent();
         assertThat(result.get().getLevel()).isEqualTo(AdminLevel.ADMIN);
         assertThat(result.get().isActive()).isTrue();
 
-        Optional<Admin> persisted = adminRepository.findByClerkId("clerk_fresh");
+        Optional<Admin> persisted = adminRepository.findByClerkId("user_boot");
         assertThat(persisted).isPresent();
         assertThat(persisted.get().getGrantedBy()).isEqualTo("BOOTSTRAP");
+        assertThat(persisted.get().getEmail()).isEqualTo("boot@devine.com");
     }
 
     @Test
-    @DisplayName("회수된 관리자의 이메일이 부트스트랩 목록에 남아 있어도 재등록 없이 빈 Optional을 반환한다 (500 아님)")
+    @DisplayName("email 클레임이 없어도(null) 부트스트랩 clerk_id면 등록된다")
+    void bootstrap_seeds_without_email() {
+        Optional<Admin> result = adminAuthorizationService.resolveAdmin("user_boot", null);
+
+        assertThat(result).isPresent();
+        assertThat(adminRepository.findByClerkId("user_boot"))
+                .get().extracting(Admin::getEmail).isNull();
+    }
+
+    @Test
+    @DisplayName("부트스트랩 clerk_id가 아니면 빈 Optional을 반환한다")
+    void non_bootstrap_returns_empty() {
+        Optional<Admin> result = adminAuthorizationService.resolveAdmin("user_stranger", "stranger@devine.com");
+
+        assertThat(result).isEmpty();
+        assertThat(adminRepository.findByClerkId("user_stranger")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("회수된 관리자는 부트스트랩 목록에 clerk_id가 남아 있어도 재등록 없이 빈 Optional을 반환한다 (500 아님)")
     void revoked_bootstrap_admin_is_not_reseeded() {
-        // given: 이메일은 부트스트랩 목록에 있지만 회수(비활성)된 관리자
+        // given: 부트스트랩 목록에 있는 clerk_id지만 회수(비활성)된 관리자
         Admin revoked = adminRepository.save(Admin.builder()
-                .clerkId("clerk_old")
+                .clerkId("user_revoked")
                 .email("revoked@devine.com")
                 .build());
         revoked.deactivate();
         adminRepository.saveAndFlush(revoked);
 
-        // when / then: 수정 전에는 UNIQUE 위반 → 트랜잭션 abort로 500이 나던 경로.
-        // 예외 없이 빈 Optional이어야 한다.
+        // when / then: 예외 없이 빈 Optional (수정 전에는 UNIQUE 위반 → abort → 500이던 경로)
         assertThatCode(() ->
-                assertThat(adminAuthorizationService.resolveAdmin("clerk_new", "revoked@devine.com")).isEmpty()
+                assertThat(adminAuthorizationService.resolveAdmin("user_revoked", "revoked@devine.com")).isEmpty()
         ).doesNotThrowAnyException();
 
-        // 새 clerk_id로 재등록되지 않았다
-        assertThat(adminRepository.findByClerkId("clerk_new")).isEmpty();
-        // 기존 회수 행은 그대로 비활성
-        assertThat(adminRepository.findByEmail("revoked@devine.com"))
-                .get()
-                .extracting(Admin::isActive)
-                .isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("관리자도 부트스트랩 이메일도 아니면 빈 Optional을 반환한다")
-    void non_admin_returns_empty() {
-        Optional<Admin> result = adminAuthorizationService.resolveAdmin("clerk_user", "user@devine.com");
-
-        assertThat(result).isEmpty();
+        // 여전히 비활성 1건, 중복 등록 없음
+        assertThat(adminRepository.findByClerkId("user_revoked"))
+                .get().extracting(Admin::isActive).isEqualTo(false);
     }
 }

--- a/devine-api/src/test/java/com/umc/devine/admin/auth/service/AdminAuthorizationServiceIntegrationTest.java
+++ b/devine-api/src/test/java/com/umc/devine/admin/auth/service/AdminAuthorizationServiceIntegrationTest.java
@@ -1,0 +1,77 @@
+package com.umc.devine.admin.auth.service;
+
+import com.umc.devine.admin.entity.Admin;
+import com.umc.devine.admin.enums.AdminLevel;
+import com.umc.devine.admin.repository.AdminRepository;
+import com.umc.devine.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * 실제 Postgres에 대해 AdminAuthorizationService의 seeding/회수 동작을 검증한다.
+ * (네이티브 ON CONFLICT upsert가 실제 스키마에서 동작하는지, 회수된 부트스트랩 관리자가 500 없이 거절되는지)
+ */
+@TestPropertySource(properties = "admin.bootstrap-emails=boot@devine.com,revoked@devine.com")
+class AdminAuthorizationServiceIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private AdminAuthorizationService adminAuthorizationService;
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Test
+    @DisplayName("부트스트랩 이메일로 최초 접근하면 admin 테이블에 자동 등록되고 활성 관리자로 반환된다")
+    void bootstrap_seeds_admin() {
+        Optional<Admin> result = adminAuthorizationService.resolveAdmin("clerk_fresh", "boot@devine.com");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getLevel()).isEqualTo(AdminLevel.ADMIN);
+        assertThat(result.get().isActive()).isTrue();
+
+        Optional<Admin> persisted = adminRepository.findByClerkId("clerk_fresh");
+        assertThat(persisted).isPresent();
+        assertThat(persisted.get().getGrantedBy()).isEqualTo("BOOTSTRAP");
+    }
+
+    @Test
+    @DisplayName("회수된 관리자의 이메일이 부트스트랩 목록에 남아 있어도 재등록 없이 빈 Optional을 반환한다 (500 아님)")
+    void revoked_bootstrap_admin_is_not_reseeded() {
+        // given: 이메일은 부트스트랩 목록에 있지만 회수(비활성)된 관리자
+        Admin revoked = adminRepository.save(Admin.builder()
+                .clerkId("clerk_old")
+                .email("revoked@devine.com")
+                .build());
+        revoked.deactivate();
+        adminRepository.saveAndFlush(revoked);
+
+        // when / then: 수정 전에는 UNIQUE 위반 → 트랜잭션 abort로 500이 나던 경로.
+        // 예외 없이 빈 Optional이어야 한다.
+        assertThatCode(() ->
+                assertThat(adminAuthorizationService.resolveAdmin("clerk_new", "revoked@devine.com")).isEmpty()
+        ).doesNotThrowAnyException();
+
+        // 새 clerk_id로 재등록되지 않았다
+        assertThat(adminRepository.findByClerkId("clerk_new")).isEmpty();
+        // 기존 회수 행은 그대로 비활성
+        assertThat(adminRepository.findByEmail("revoked@devine.com"))
+                .get()
+                .extracting(Admin::isActive)
+                .isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("관리자도 부트스트랩 이메일도 아니면 빈 Optional을 반환한다")
+    void non_admin_returns_empty() {
+        Optional<Admin> result = adminAuthorizationService.resolveAdmin("clerk_user", "user@devine.com");
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/devine-api/src/test/java/com/umc/devine/admin/auth/service/AdminAuthorizationServiceTest.java
+++ b/devine-api/src/test/java/com/umc/devine/admin/auth/service/AdminAuthorizationServiceTest.java
@@ -1,0 +1,146 @@
+package com.umc.devine.admin.auth.service;
+
+import com.umc.devine.admin.entity.Admin;
+import com.umc.devine.admin.enums.AdminLevel;
+import com.umc.devine.admin.repository.AdminRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AdminAuthorizationServiceTest {
+
+    @Mock
+    private AdminRepository adminRepository;
+
+    private AdminAuthorizationService service(String bootstrapEmails) {
+        return new AdminAuthorizationService(adminRepository, bootstrapEmails);
+    }
+
+    private Admin admin(String clerkId, String email) {
+        return Admin.builder().clerkId(clerkId).email(email).build();
+    }
+
+    @Nested
+    @DisplayName("기존 관리자")
+    class ExistingAdmin {
+
+        @Test
+        @DisplayName("admin 테이블에 활성 관리자가 있으면 그대로 반환하고 등록하지 않는다")
+        void returns_existing_without_seeding() {
+            // given
+            given(adminRepository.findActiveByClerkId("clerk_1"))
+                    .willReturn(Optional.of(admin("clerk_1", "a@devine.com")));
+
+            // when
+            Optional<Admin> result = service("a@devine.com").resolveAdmin("clerk_1", "a@devine.com");
+
+            // then
+            assertThat(result).isPresent();
+            verify(adminRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("부트스트랩 lazy seeding")
+    class Bootstrap {
+
+        @Test
+        @DisplayName("부트스트랩 이메일로 최초 접근 시 admin 테이블에 자동 등록한다")
+        void seeds_on_first_bootstrap_access() {
+            // given
+            given(adminRepository.findActiveByClerkId("clerk_2")).willReturn(Optional.empty());
+            given(adminRepository.findActiveByEmail("boot@devine.com")).willReturn(Optional.empty());
+            given(adminRepository.save(any(Admin.class))).willAnswer(inv -> inv.getArgument(0));
+
+            // when
+            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_2", "boot@devine.com");
+
+            // then
+            assertThat(result).isPresent();
+            ArgumentCaptor<Admin> captor = ArgumentCaptor.forClass(Admin.class);
+            verify(adminRepository).save(captor.capture());
+            Admin saved = captor.getValue();
+            assertThat(saved.getClerkId()).isEqualTo("clerk_2");
+            assertThat(saved.getEmail()).isEqualTo("boot@devine.com");
+            assertThat(saved.getLevel()).isEqualTo(AdminLevel.ADMIN);
+        }
+
+        @Test
+        @DisplayName("부트스트랩 이메일 매칭은 대소문자/공백을 무시한다")
+        void bootstrap_match_is_normalized() {
+            // given
+            given(adminRepository.findActiveByClerkId("clerk_3")).willReturn(Optional.empty());
+            given(adminRepository.findActiveByEmail("boot@devine.com")).willReturn(Optional.empty());
+            given(adminRepository.save(any(Admin.class))).willAnswer(inv -> inv.getArgument(0));
+
+            // when: 설정은 대문자/공백 포함, 토큰 이메일도 대문자
+            Optional<Admin> result = service("  BOOT@Devine.com ").resolveAdmin("clerk_3", "Boot@DEVINE.com");
+
+            // then
+            assertThat(result).isPresent();
+            verify(adminRepository).save(any(Admin.class));
+        }
+
+        @Test
+        @DisplayName("이미 같은 이메일의 관리자가 있으면 등록하지 않고 재사용한다")
+        void reuses_when_email_already_registered() {
+            // given
+            given(adminRepository.findActiveByClerkId("clerk_4")).willReturn(Optional.empty());
+            given(adminRepository.findActiveByEmail("boot@devine.com"))
+                    .willReturn(Optional.of(admin("other_clerk", "boot@devine.com")));
+
+            // when
+            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_4", "boot@devine.com");
+
+            // then
+            assertThat(result).isPresent();
+            verify(adminRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("비관리자")
+    class NonAdmin {
+
+        @Test
+        @DisplayName("관리자도 아니고 부트스트랩 이메일도 아니면 빈 Optional을 반환한다")
+        void returns_empty_for_non_admin() {
+            // given
+            given(adminRepository.findActiveByClerkId("clerk_5")).willReturn(Optional.empty());
+
+            // when
+            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_5", "user@devine.com");
+
+            // then
+            assertThat(result).isEmpty();
+            verify(adminRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("부트스트랩 목록이 비어 있으면 아무도 자동 등록되지 않는다")
+        void empty_bootstrap_grants_nobody() {
+            // given
+            given(adminRepository.findActiveByClerkId("clerk_6")).willReturn(Optional.empty());
+
+            // when
+            Optional<Admin> result = service("").resolveAdmin("clerk_6", "user@devine.com");
+
+            // then
+            assertThat(result).isEmpty();
+            verify(adminRepository, never()).save(any());
+        }
+    }
+}

--- a/devine-api/src/test/java/com/umc/devine/admin/auth/service/AdminAuthorizationServiceTest.java
+++ b/devine-api/src/test/java/com/umc/devine/admin/auth/service/AdminAuthorizationServiceTest.java
@@ -1,13 +1,11 @@
 package com.umc.devine.admin.auth.service;
 
 import com.umc.devine.admin.entity.Admin;
-import com.umc.devine.admin.enums.AdminLevel;
 import com.umc.devine.admin.repository.AdminRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -15,6 +13,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,23 +32,42 @@ class AdminAuthorizationServiceTest {
         return Admin.builder().clerkId(clerkId).email(email).build();
     }
 
+    private Admin deactivatedAdmin(String clerkId, String email) {
+        Admin admin = admin(clerkId, email);
+        admin.deactivate();
+        return admin;
+    }
+
+    private void verifyNoSeeding() {
+        verify(adminRepository, never()).insertBootstrapAdminIfAbsent(any(), any(), any());
+    }
+
     @Nested
     @DisplayName("기존 관리자")
     class ExistingAdmin {
 
         @Test
-        @DisplayName("admin 테이블에 활성 관리자가 있으면 그대로 반환하고 등록하지 않는다")
-        void returns_existing_without_seeding() {
-            // given
-            given(adminRepository.findActiveByClerkId("clerk_1"))
+        @DisplayName("활성 관리자가 clerkId로 존재하면 그대로 반환하고 등록하지 않는다")
+        void returns_existing_active() {
+            given(adminRepository.findByClerkId("clerk_1"))
                     .willReturn(Optional.of(admin("clerk_1", "a@devine.com")));
 
-            // when
             Optional<Admin> result = service("a@devine.com").resolveAdmin("clerk_1", "a@devine.com");
 
-            // then
             assertThat(result).isPresent();
-            verify(adminRepository, never()).save(any());
+            verifyNoSeeding();
+        }
+
+        @Test
+        @DisplayName("회수(비활성)된 관리자는 부트스트랩 목록에 남아 있어도 빈 Optional을 반환한다 (회수 우선)")
+        void revoked_admin_by_clerk_id_returns_empty() {
+            given(adminRepository.findByClerkId("clerk_revoked"))
+                    .willReturn(Optional.of(deactivatedAdmin("clerk_revoked", "boot@devine.com")));
+
+            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_revoked", "boot@devine.com");
+
+            assertThat(result).isEmpty();
+            verifyNoSeeding();
         }
     }
 
@@ -58,56 +76,56 @@ class AdminAuthorizationServiceTest {
     class Bootstrap {
 
         @Test
-        @DisplayName("부트스트랩 이메일로 최초 접근 시 admin 테이블에 자동 등록한다")
+        @DisplayName("부트스트랩 이메일로 최초 접근 시 자동 등록 후 관리자를 반환한다")
         void seeds_on_first_bootstrap_access() {
-            // given
-            given(adminRepository.findActiveByClerkId("clerk_2")).willReturn(Optional.empty());
-            given(adminRepository.findActiveByEmail("boot@devine.com")).willReturn(Optional.empty());
-            given(adminRepository.save(any(Admin.class))).willAnswer(inv -> inv.getArgument(0));
+            given(adminRepository.findByClerkId("clerk_2"))
+                    .willReturn(Optional.empty(), Optional.of(admin("clerk_2", "boot@devine.com")));
+            given(adminRepository.findByEmail("boot@devine.com")).willReturn(Optional.empty());
 
-            // when
             Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_2", "boot@devine.com");
 
-            // then
             assertThat(result).isPresent();
-            ArgumentCaptor<Admin> captor = ArgumentCaptor.forClass(Admin.class);
-            verify(adminRepository).save(captor.capture());
-            Admin saved = captor.getValue();
-            assertThat(saved.getClerkId()).isEqualTo("clerk_2");
-            assertThat(saved.getEmail()).isEqualTo("boot@devine.com");
-            assertThat(saved.getLevel()).isEqualTo(AdminLevel.ADMIN);
+            verify(adminRepository).insertBootstrapAdminIfAbsent("clerk_2", "boot@devine.com", "BOOTSTRAP");
         }
 
         @Test
-        @DisplayName("부트스트랩 이메일 매칭은 대소문자/공백을 무시한다")
-        void bootstrap_match_is_normalized() {
-            // given
-            given(adminRepository.findActiveByClerkId("clerk_3")).willReturn(Optional.empty());
-            given(adminRepository.findActiveByEmail("boot@devine.com")).willReturn(Optional.empty());
-            given(adminRepository.save(any(Admin.class))).willAnswer(inv -> inv.getArgument(0));
+        @DisplayName("부트스트랩 이메일 매칭과 등록은 대소문자/공백을 정규화한다")
+        void bootstrap_match_and_insert_are_normalized() {
+            given(adminRepository.findByClerkId("clerk_3"))
+                    .willReturn(Optional.empty(), Optional.of(admin("clerk_3", "boot@devine.com")));
+            given(adminRepository.findByEmail("boot@devine.com")).willReturn(Optional.empty());
 
-            // when: 설정은 대문자/공백 포함, 토큰 이메일도 대문자
+            // 설정과 토큰 이메일 모두 대문자/공백 포함
             Optional<Admin> result = service("  BOOT@Devine.com ").resolveAdmin("clerk_3", "Boot@DEVINE.com");
 
-            // then
             assertThat(result).isPresent();
-            verify(adminRepository).save(any(Admin.class));
+            verify(adminRepository).insertBootstrapAdminIfAbsent(eq("clerk_3"), eq("boot@devine.com"), eq("BOOTSTRAP"));
         }
 
         @Test
-        @DisplayName("이미 같은 이메일의 관리자가 있으면 등록하지 않고 재사용한다")
-        void reuses_when_email_already_registered() {
-            // given
-            given(adminRepository.findActiveByClerkId("clerk_4")).willReturn(Optional.empty());
-            given(adminRepository.findActiveByEmail("boot@devine.com"))
+        @DisplayName("이미 같은 이메일의 활성 관리자가 있으면 등록하지 않고 재사용한다")
+        void reuses_when_active_email_exists() {
+            given(adminRepository.findByClerkId("clerk_4")).willReturn(Optional.empty());
+            given(adminRepository.findByEmail("boot@devine.com"))
                     .willReturn(Optional.of(admin("other_clerk", "boot@devine.com")));
 
-            // when
             Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_4", "boot@devine.com");
 
-            // then
             assertThat(result).isPresent();
-            verify(adminRepository, never()).save(any());
+            verifyNoSeeding();
+        }
+
+        @Test
+        @DisplayName("같은 이메일의 관리자가 회수(비활성)되어 있으면 재등록하지 않고 빈 Optional을 반환한다")
+        void revoked_admin_by_email_returns_empty() {
+            given(adminRepository.findByClerkId("clerk_5")).willReturn(Optional.empty());
+            given(adminRepository.findByEmail("boot@devine.com"))
+                    .willReturn(Optional.of(deactivatedAdmin("old_clerk", "boot@devine.com")));
+
+            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_5", "boot@devine.com");
+
+            assertThat(result).isEmpty();
+            verifyNoSeeding();
         }
     }
 
@@ -118,29 +136,23 @@ class AdminAuthorizationServiceTest {
         @Test
         @DisplayName("관리자도 아니고 부트스트랩 이메일도 아니면 빈 Optional을 반환한다")
         void returns_empty_for_non_admin() {
-            // given
-            given(adminRepository.findActiveByClerkId("clerk_5")).willReturn(Optional.empty());
+            given(adminRepository.findByClerkId("clerk_6")).willReturn(Optional.empty());
 
-            // when
-            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_5", "user@devine.com");
+            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_6", "user@devine.com");
 
-            // then
             assertThat(result).isEmpty();
-            verify(adminRepository, never()).save(any());
+            verifyNoSeeding();
         }
 
         @Test
         @DisplayName("부트스트랩 목록이 비어 있으면 아무도 자동 등록되지 않는다")
         void empty_bootstrap_grants_nobody() {
-            // given
-            given(adminRepository.findActiveByClerkId("clerk_6")).willReturn(Optional.empty());
+            given(adminRepository.findByClerkId("clerk_7")).willReturn(Optional.empty());
 
-            // when
-            Optional<Admin> result = service("").resolveAdmin("clerk_6", "user@devine.com");
+            Optional<Admin> result = service("").resolveAdmin("clerk_7", "user@devine.com");
 
-            // then
             assertThat(result).isEmpty();
-            verify(adminRepository, never()).save(any());
+            verifyNoSeeding();
         }
     }
 }

--- a/devine-api/src/test/java/com/umc/devine/admin/auth/service/AdminAuthorizationServiceTest.java
+++ b/devine-api/src/test/java/com/umc/devine/admin/auth/service/AdminAuthorizationServiceTest.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -24,8 +25,8 @@ class AdminAuthorizationServiceTest {
     @Mock
     private AdminRepository adminRepository;
 
-    private AdminAuthorizationService service(String bootstrapEmails) {
-        return new AdminAuthorizationService(adminRepository, bootstrapEmails);
+    private AdminAuthorizationService service(String bootstrapClerkIds) {
+        return new AdminAuthorizationService(adminRepository, bootstrapClerkIds);
     }
 
     private Admin admin(String clerkId, String email) {
@@ -49,10 +50,10 @@ class AdminAuthorizationServiceTest {
         @Test
         @DisplayName("활성 관리자가 clerkId로 존재하면 그대로 반환하고 등록하지 않는다")
         void returns_existing_active() {
-            given(adminRepository.findByClerkId("clerk_1"))
-                    .willReturn(Optional.of(admin("clerk_1", "a@devine.com")));
+            given(adminRepository.findByClerkId("user_1"))
+                    .willReturn(Optional.of(admin("user_1", "a@devine.com")));
 
-            Optional<Admin> result = service("a@devine.com").resolveAdmin("clerk_1", "a@devine.com");
+            Optional<Admin> result = service("user_1").resolveAdmin("user_1", "a@devine.com");
 
             assertThat(result).isPresent();
             verifyNoSeeding();
@@ -60,11 +61,11 @@ class AdminAuthorizationServiceTest {
 
         @Test
         @DisplayName("회수(비활성)된 관리자는 부트스트랩 목록에 남아 있어도 빈 Optional을 반환한다 (회수 우선)")
-        void revoked_admin_by_clerk_id_returns_empty() {
-            given(adminRepository.findByClerkId("clerk_revoked"))
-                    .willReturn(Optional.of(deactivatedAdmin("clerk_revoked", "boot@devine.com")));
+        void revoked_admin_returns_empty() {
+            given(adminRepository.findByClerkId("user_revoked"))
+                    .willReturn(Optional.of(deactivatedAdmin("user_revoked", "boot@devine.com")));
 
-            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_revoked", "boot@devine.com");
+            Optional<Admin> result = service("user_revoked").resolveAdmin("user_revoked", "boot@devine.com");
 
             assertThat(result).isEmpty();
             verifyNoSeeding();
@@ -72,60 +73,43 @@ class AdminAuthorizationServiceTest {
     }
 
     @Nested
-    @DisplayName("부트스트랩 lazy seeding")
+    @DisplayName("부트스트랩 lazy seeding (clerk_id 기반)")
     class Bootstrap {
 
         @Test
-        @DisplayName("부트스트랩 이메일로 최초 접근 시 자동 등록 후 관리자를 반환한다")
+        @DisplayName("부트스트랩 clerk_id로 최초 접근 시 자동 등록 후 관리자를 반환한다")
         void seeds_on_first_bootstrap_access() {
-            given(adminRepository.findByClerkId("clerk_2"))
-                    .willReturn(Optional.empty(), Optional.of(admin("clerk_2", "boot@devine.com")));
-            given(adminRepository.findByEmail("boot@devine.com")).willReturn(Optional.empty());
+            given(adminRepository.findByClerkId("user_2"))
+                    .willReturn(Optional.empty(), Optional.of(admin("user_2", "boot@devine.com")));
 
-            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_2", "boot@devine.com");
+            Optional<Admin> result = service("user_2").resolveAdmin("user_2", "boot@devine.com");
 
             assertThat(result).isPresent();
-            verify(adminRepository).insertBootstrapAdminIfAbsent("clerk_2", "boot@devine.com", "BOOTSTRAP");
+            verify(adminRepository).insertBootstrapAdminIfAbsent(eq("user_2"), eq("boot@devine.com"), eq("BOOTSTRAP"));
         }
 
         @Test
-        @DisplayName("부트스트랩 이메일 매칭과 등록은 대소문자/공백을 정규화한다")
-        void bootstrap_match_and_insert_are_normalized() {
-            given(adminRepository.findByClerkId("clerk_3"))
-                    .willReturn(Optional.empty(), Optional.of(admin("clerk_3", "boot@devine.com")));
-            given(adminRepository.findByEmail("boot@devine.com")).willReturn(Optional.empty());
+        @DisplayName("email 클레임이 없어도(null) clerk_id만으로 자동 등록된다")
+        void seeds_even_without_email() {
+            given(adminRepository.findByClerkId("user_3"))
+                    .willReturn(Optional.empty(), Optional.of(admin("user_3", null)));
 
-            // 설정과 토큰 이메일 모두 대문자/공백 포함
-            Optional<Admin> result = service("  BOOT@Devine.com ").resolveAdmin("clerk_3", "Boot@DEVINE.com");
+            Optional<Admin> result = service("user_3").resolveAdmin("user_3", null);
 
             assertThat(result).isPresent();
-            verify(adminRepository).insertBootstrapAdminIfAbsent(eq("clerk_3"), eq("boot@devine.com"), eq("BOOTSTRAP"));
+            verify(adminRepository).insertBootstrapAdminIfAbsent(eq("user_3"), isNull(), eq("BOOTSTRAP"));
         }
 
         @Test
-        @DisplayName("이미 같은 이메일의 활성 관리자가 있으면 등록하지 않고 재사용한다")
-        void reuses_when_active_email_exists() {
-            given(adminRepository.findByClerkId("clerk_4")).willReturn(Optional.empty());
-            given(adminRepository.findByEmail("boot@devine.com"))
-                    .willReturn(Optional.of(admin("other_clerk", "boot@devine.com")));
+        @DisplayName("email은 정규화되어 저장된다(대소문자/공백)")
+        void email_is_normalized_on_insert() {
+            given(adminRepository.findByClerkId("user_4"))
+                    .willReturn(Optional.empty(), Optional.of(admin("user_4", "boot@devine.com")));
 
-            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_4", "boot@devine.com");
+            Optional<Admin> result = service("user_4").resolveAdmin("user_4", "  Boot@DEVINE.com ");
 
             assertThat(result).isPresent();
-            verifyNoSeeding();
-        }
-
-        @Test
-        @DisplayName("같은 이메일의 관리자가 회수(비활성)되어 있으면 재등록하지 않고 빈 Optional을 반환한다")
-        void revoked_admin_by_email_returns_empty() {
-            given(adminRepository.findByClerkId("clerk_5")).willReturn(Optional.empty());
-            given(adminRepository.findByEmail("boot@devine.com"))
-                    .willReturn(Optional.of(deactivatedAdmin("old_clerk", "boot@devine.com")));
-
-            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_5", "boot@devine.com");
-
-            assertThat(result).isEmpty();
-            verifyNoSeeding();
+            verify(adminRepository).insertBootstrapAdminIfAbsent(eq("user_4"), eq("boot@devine.com"), eq("BOOTSTRAP"));
         }
     }
 
@@ -134,11 +118,11 @@ class AdminAuthorizationServiceTest {
     class NonAdmin {
 
         @Test
-        @DisplayName("관리자도 아니고 부트스트랩 이메일도 아니면 빈 Optional을 반환한다")
+        @DisplayName("부트스트랩 clerk_id도 아니고 기존 관리자도 아니면 빈 Optional을 반환한다")
         void returns_empty_for_non_admin() {
-            given(adminRepository.findByClerkId("clerk_6")).willReturn(Optional.empty());
+            given(adminRepository.findByClerkId("user_5")).willReturn(Optional.empty());
 
-            Optional<Admin> result = service("boot@devine.com").resolveAdmin("clerk_6", "user@devine.com");
+            Optional<Admin> result = service("user_2").resolveAdmin("user_5", "user@devine.com");
 
             assertThat(result).isEmpty();
             verifyNoSeeding();
@@ -147,9 +131,9 @@ class AdminAuthorizationServiceTest {
         @Test
         @DisplayName("부트스트랩 목록이 비어 있으면 아무도 자동 등록되지 않는다")
         void empty_bootstrap_grants_nobody() {
-            given(adminRepository.findByClerkId("clerk_7")).willReturn(Optional.empty());
+            given(adminRepository.findByClerkId("user_6")).willReturn(Optional.empty());
 
-            Optional<Admin> result = service("").resolveAdmin("clerk_7", "user@devine.com");
+            Optional<Admin> result = service("").resolveAdmin("user_6", "user@devine.com");
 
             assertThat(result).isEmpty();
             verifyNoSeeding();

--- a/devine-core/src/main/java/com/umc/devine/admin/entity/Admin.java
+++ b/devine-core/src/main/java/com/umc/devine/admin/entity/Admin.java
@@ -1,0 +1,54 @@
+package com.umc.devine.admin.entity;
+
+import com.umc.devine.admin.enums.AdminLevel;
+import com.umc.devine.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "admin")
+public class Admin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "admin_id")
+    private Long id;
+
+    @Column(name = "clerk_id", nullable = false, unique = true, length = 255)
+    private String clerkId;
+
+    @Column(nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    @Builder.Default
+    private AdminLevel level = AdminLevel.ADMIN;
+
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private boolean isActive = true;
+
+    @Column(name = "granted_by", length = 255)
+    private String grantedBy;
+
+    /** 관리자 권한 회수 (소프트 삭제) */
+    public void deactivate() {
+        this.isActive = false;
+    }
+}

--- a/devine-core/src/main/java/com/umc/devine/admin/entity/Admin.java
+++ b/devine-core/src/main/java/com/umc/devine/admin/entity/Admin.java
@@ -32,7 +32,8 @@ public class Admin extends BaseEntity {
     @Column(name = "clerk_id", nullable = false, unique = true, length = 255)
     private String clerkId;
 
-    @Column(nullable = false, unique = true, length = 255)
+    // 판정은 clerk_id로만 한다. email은 표시/감사용 부가 정보라 nullable.
+    @Column(unique = true, length = 255)
     private String email;
 
     @Enumerated(EnumType.STRING)

--- a/devine-core/src/main/java/com/umc/devine/admin/enums/AdminLevel.java
+++ b/devine-core/src/main/java/com/umc/devine/admin/enums/AdminLevel.java
@@ -1,0 +1,10 @@
+package com.umc.devine.admin.enums;
+
+/**
+ * 관리자 권한 레벨.
+ * 현재는 단일 ADMIN만 사용하며, 다단계 권한이 필요해지면 이 enum과
+ * admin_level_check 제약(마이그레이션)을 함께 확장한다.
+ */
+public enum AdminLevel {
+    ADMIN
+}

--- a/devine-core/src/main/java/com/umc/devine/admin/repository/AdminRepository.java
+++ b/devine-core/src/main/java/com/umc/devine/admin/repository/AdminRepository.java
@@ -1,0 +1,17 @@
+package com.umc.devine.admin.repository;
+
+import com.umc.devine.admin.entity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    @Query("SELECT a FROM Admin a WHERE a.clerkId = :clerkId AND a.isActive = true")
+    Optional<Admin> findActiveByClerkId(@Param("clerkId") String clerkId);
+
+    @Query("SELECT a FROM Admin a WHERE a.email = :email AND a.isActive = true")
+    Optional<Admin> findActiveByEmail(@Param("email") String email);
+}

--- a/devine-core/src/main/java/com/umc/devine/admin/repository/AdminRepository.java
+++ b/devine-core/src/main/java/com/umc/devine/admin/repository/AdminRepository.java
@@ -12,19 +12,17 @@ public interface AdminRepository extends JpaRepository<Admin, Long> {
 
     // 활성 여부와 무관하게 존재를 확인한다. 회수(비활성)된 관리자도 조회되어야
     // 부트스트랩 재등록을 막고 UNIQUE 제약 위반(→ 트랜잭션 abort → 500)을 피할 수 있다.
-    // clerk_id, email 각각 UNIQUE이므로 개별 조회는 항상 단일 결과이다(OR 병합 시 다중행 위험).
     Optional<Admin> findByClerkId(String clerkId);
-
-    Optional<Admin> findByEmail(String email);
 
     /**
      * 부트스트랩 관리자를 멱등하게 삽입한다.
      *
-     * <p>대상 없는 {@code ON CONFLICT DO NOTHING}이라 clerk_id/email 어느 UNIQUE에 충돌하든
+     * <p>대상 없는 {@code ON CONFLICT DO NOTHING}이라 clerk_id(또는 email) UNIQUE에 충돌해도
      * 예외 없이 no-op된다. 덕분에 @Transactional 안에서 제약 위반으로 트랜잭션이 abort되는 문제를
      * 원천 차단한다. 단 DO NOTHING은 행을 반환하지 않으므로 호출부에서 후속 SELECT가 필요하다.
      *
-     * <p>level / is_active / created_at은 테이블 기본값을 사용한다.
+     * <p>email은 nullable이며 판정에는 쓰이지 않는다(표시/감사용).
+     * level / is_active / created_at은 테이블 기본값을 사용한다.
      * created_by는 네이티브 INSERT라 JPA 감사(auditing)를 우회해 null이며, 출처는 granted_by로 남긴다.
      */
     @Modifying

--- a/devine-core/src/main/java/com/umc/devine/admin/repository/AdminRepository.java
+++ b/devine-core/src/main/java/com/umc/devine/admin/repository/AdminRepository.java
@@ -2,6 +2,7 @@ package com.umc.devine.admin.repository;
 
 import com.umc.devine.admin.entity.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -9,9 +10,28 @@ import java.util.Optional;
 
 public interface AdminRepository extends JpaRepository<Admin, Long> {
 
-    @Query("SELECT a FROM Admin a WHERE a.clerkId = :clerkId AND a.isActive = true")
-    Optional<Admin> findActiveByClerkId(@Param("clerkId") String clerkId);
+    // 활성 여부와 무관하게 존재를 확인한다. 회수(비활성)된 관리자도 조회되어야
+    // 부트스트랩 재등록을 막고 UNIQUE 제약 위반(→ 트랜잭션 abort → 500)을 피할 수 있다.
+    // clerk_id, email 각각 UNIQUE이므로 개별 조회는 항상 단일 결과이다(OR 병합 시 다중행 위험).
+    Optional<Admin> findByClerkId(String clerkId);
 
-    @Query("SELECT a FROM Admin a WHERE a.email = :email AND a.isActive = true")
-    Optional<Admin> findActiveByEmail(@Param("email") String email);
+    Optional<Admin> findByEmail(String email);
+
+    /**
+     * 부트스트랩 관리자를 멱등하게 삽입한다.
+     *
+     * <p>대상 없는 {@code ON CONFLICT DO NOTHING}이라 clerk_id/email 어느 UNIQUE에 충돌하든
+     * 예외 없이 no-op된다. 덕분에 @Transactional 안에서 제약 위반으로 트랜잭션이 abort되는 문제를
+     * 원천 차단한다. 단 DO NOTHING은 행을 반환하지 않으므로 호출부에서 후속 SELECT가 필요하다.
+     *
+     * <p>level / is_active / created_at은 테이블 기본값을 사용한다.
+     * created_by는 네이티브 INSERT라 JPA 감사(auditing)를 우회해 null이며, 출처는 granted_by로 남긴다.
+     */
+    @Modifying
+    @Query(value = "INSERT INTO admin (clerk_id, email, granted_by) "
+            + "VALUES (:clerkId, :email, :grantedBy) "
+            + "ON CONFLICT DO NOTHING", nativeQuery = true)
+    void insertBootstrapAdminIfAbsent(@Param("clerkId") String clerkId,
+                                      @Param("email") String email,
+                                      @Param("grantedBy") String grantedBy);
 }

--- a/devine-core/src/main/resources/db/migration/V20260719120000__294_add_admin_table.sql
+++ b/devine-core/src/main/resources/db/migration/V20260719120000__294_add_admin_table.sql
@@ -1,0 +1,15 @@
+-- admin 테이블 (관리자 인증/인가)
+-- 관리자도 Clerk로 로그인하며, 이 테이블은 "누가 관리자인가"(clerk_id)와 권한 레벨을 관리한다.
+CREATE TABLE admin (
+    admin_id    BIGSERIAL    PRIMARY KEY,
+    clerk_id    VARCHAR(255) NOT NULL UNIQUE,
+    email       VARCHAR(255) NOT NULL UNIQUE,
+    level       VARCHAR(30)  NOT NULL DEFAULT 'ADMIN',
+    is_active   BOOLEAN      NOT NULL DEFAULT TRUE,
+    granted_by  VARCHAR(255),
+    created_at  TIMESTAMP(6) NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMP(6),
+    created_by  VARCHAR(255),
+    updated_by  VARCHAR(255),
+    CONSTRAINT admin_level_check CHECK (level IN ('ADMIN'))
+);

--- a/devine-core/src/main/resources/db/migration/V20260719120000__294_add_admin_table.sql
+++ b/devine-core/src/main/resources/db/migration/V20260719120000__294_add_admin_table.sql
@@ -11,5 +11,7 @@ CREATE TABLE admin (
     updated_at  TIMESTAMP(6),
     created_by  VARCHAR(255),
     updated_by  VARCHAR(255),
+    -- ⚠️ level 확장 시: AdminLevel enum에 값을 추가하면 이 CHECK도 새 마이그레이션으로 함께 갱신해야 한다.
+    -- (누락 시 새 레벨 INSERT가 CHECK 위반 → 트랜잭션 abort로 이어져 로그인이 500으로 깨진다)
     CONSTRAINT admin_level_check CHECK (level IN ('ADMIN'))
 );

--- a/devine-core/src/main/resources/db/migration/V20260719120000__294_add_admin_table.sql
+++ b/devine-core/src/main/resources/db/migration/V20260719120000__294_add_admin_table.sql
@@ -1,9 +1,11 @@
 -- admin 테이블 (관리자 인증/인가)
 -- 관리자도 Clerk로 로그인하며, 이 테이블은 "누가 관리자인가"(clerk_id)와 권한 레벨을 관리한다.
+-- 관리자 판정/부트스트랩은 clerk_id(sub, 위조 불가)만 신뢰한다. email은 표시/감사용 부가 정보라 nullable이다
+-- (Clerk 세션 토큰에 email 클레임이 없어도 관리자 등록이 되어야 하므로).
 CREATE TABLE admin (
     admin_id    BIGSERIAL    PRIMARY KEY,
     clerk_id    VARCHAR(255) NOT NULL UNIQUE,
-    email       VARCHAR(255) NOT NULL UNIQUE,
+    email       VARCHAR(255) UNIQUE,
     level       VARCHAR(30)  NOT NULL DEFAULT 'ADMIN',
     is_active   BOOLEAN      NOT NULL DEFAULT TRUE,
     granted_by  VARCHAR(255),

--- a/devine-core/src/test/java/com/umc/devine/admin/repository/AdminRepositoryTest.java
+++ b/devine-core/src/test/java/com/umc/devine/admin/repository/AdminRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class AdminRepositoryTest extends CoreIntegrationTestSupport {
 
@@ -31,75 +32,87 @@ class AdminRepositoryTest extends CoreIntegrationTestSupport {
         @Test
         @DisplayName("저장 시 level은 ADMIN, isActive는 true가 기본값이다")
         void defaults_applied() {
-            // when
             Admin saved = saveAdmin("admin_clerk_1", "admin1@devine.com");
 
-            // then
             assertThat(saved.getLevel()).isEqualTo(AdminLevel.ADMIN);
             assertThat(saved.isActive()).isTrue();
         }
     }
 
     @Nested
-    @DisplayName("findActiveByClerkId")
-    class FindActiveByClerkId {
+    @DisplayName("findByClerkId / findByEmail (활성 여부 무관)")
+    class Finders {
 
         @Test
-        @DisplayName("활성 관리자를 clerkId로 조회한다")
-        void returns_active_admin() {
-            // given
+        @DisplayName("활성 관리자를 clerkId/email로 조회한다")
+        void finds_active_admin() {
             saveAdmin("admin_clerk_2", "admin2@devine.com");
 
-            // when
-            Optional<Admin> result = adminRepository.findActiveByClerkId("admin_clerk_2");
-
-            // then
-            assertThat(result).isPresent();
-            assertThat(result.get().getEmail()).isEqualTo("admin2@devine.com");
+            assertThat(adminRepository.findByClerkId("admin_clerk_2")).isPresent();
+            assertThat(adminRepository.findByEmail("admin2@devine.com")).isPresent();
         }
 
         @Test
-        @DisplayName("비활성(회수) 관리자는 조회되지 않는다")
-        void ignores_deactivated_admin() {
-            // given
+        @DisplayName("비활성(회수) 관리자도 조회된다 (회수 우선 판정을 위해 활성 여부를 필터링하지 않는다)")
+        void finds_deactivated_admin() {
             Admin admin = saveAdmin("admin_clerk_3", "admin3@devine.com");
             admin.deactivate();
             adminRepository.save(admin);
 
-            // when
-            Optional<Admin> result = adminRepository.findActiveByClerkId("admin_clerk_3");
-
-            // then
-            assertThat(result).isEmpty();
+            Optional<Admin> byClerkId = adminRepository.findByClerkId("admin_clerk_3");
+            assertThat(byClerkId).isPresent();
+            assertThat(byClerkId.get().isActive()).isFalse();
+            assertThat(adminRepository.findByEmail("admin3@devine.com")).isPresent();
         }
 
         @Test
-        @DisplayName("존재하지 않는 clerkId면 빈 Optional을 반환한다")
+        @DisplayName("존재하지 않으면 빈 Optional을 반환한다")
         void returns_empty_when_absent() {
-            // when
-            Optional<Admin> result = adminRepository.findActiveByClerkId("no_such_clerk");
-
-            // then
-            assertThat(result).isEmpty();
+            assertThat(adminRepository.findByClerkId("no_such_clerk")).isEmpty();
+            assertThat(adminRepository.findByEmail("no@such.com")).isEmpty();
         }
     }
 
     @Nested
-    @DisplayName("findActiveByEmail")
-    class FindActiveByEmail {
+    @DisplayName("insertBootstrapAdminIfAbsent (ON CONFLICT DO NOTHING)")
+    class BootstrapUpsert {
 
         @Test
-        @DisplayName("활성 관리자를 email로 조회한다 (부트스트랩용)")
-        void returns_active_admin_by_email() {
-            // given
-            saveAdmin("admin_clerk_4", "admin4@devine.com");
+        @DisplayName("행이 없으면 기본값(level=ADMIN, is_active=true)으로 삽입한다")
+        void inserts_with_defaults() {
+            adminRepository.insertBootstrapAdminIfAbsent("boot_clerk_1", "boot1@devine.com", "BOOTSTRAP");
 
-            // when
-            Optional<Admin> result = adminRepository.findActiveByEmail("admin4@devine.com");
-
-            // then
+            Optional<Admin> result = adminRepository.findByClerkId("boot_clerk_1");
             assertThat(result).isPresent();
-            assertThat(result.get().getClerkId()).isEqualTo("admin_clerk_4");
+            assertThat(result.get().getLevel()).isEqualTo(AdminLevel.ADMIN);
+            assertThat(result.get().isActive()).isTrue();
+            assertThat(result.get().getGrantedBy()).isEqualTo("BOOTSTRAP");
+        }
+
+        @Test
+        @DisplayName("같은 clerk_id로 다시 호출해도 예외 없이 멱등하다 (clerk_id 충돌)")
+        void idempotent_on_clerk_id_conflict() {
+            adminRepository.insertBootstrapAdminIfAbsent("boot_clerk_2", "boot2@devine.com", "BOOTSTRAP");
+
+            assertThatCode(() ->
+                    adminRepository.insertBootstrapAdminIfAbsent("boot_clerk_2", "boot2@devine.com", "BOOTSTRAP")
+            ).doesNotThrowAnyException();
+
+            assertThat(adminRepository.findByClerkId("boot_clerk_2")).isPresent();
+        }
+
+        @Test
+        @DisplayName("다른 clerk_id + 같은 email로 호출해도 예외 없이 no-op이다 (email 충돌)")
+        void idempotent_on_email_conflict() {
+            adminRepository.insertBootstrapAdminIfAbsent("boot_clerk_3", "shared@devine.com", "BOOTSTRAP");
+
+            assertThatCode(() ->
+                    adminRepository.insertBootstrapAdminIfAbsent("boot_clerk_other", "shared@devine.com", "BOOTSTRAP")
+            ).doesNotThrowAnyException();
+
+            // email 충돌로 두 번째는 삽입되지 않는다
+            assertThat(adminRepository.findByClerkId("boot_clerk_other")).isEmpty();
+            assertThat(adminRepository.findByEmail("shared@devine.com")).isPresent();
         }
     }
 }

--- a/devine-core/src/test/java/com/umc/devine/admin/repository/AdminRepositoryTest.java
+++ b/devine-core/src/test/java/com/umc/devine/admin/repository/AdminRepositoryTest.java
@@ -40,16 +40,15 @@ class AdminRepositoryTest extends CoreIntegrationTestSupport {
     }
 
     @Nested
-    @DisplayName("findByClerkId / findByEmail (활성 여부 무관)")
+    @DisplayName("findByClerkId (활성 여부 무관)")
     class Finders {
 
         @Test
-        @DisplayName("활성 관리자를 clerkId/email로 조회한다")
+        @DisplayName("활성 관리자를 clerkId로 조회한다")
         void finds_active_admin() {
             saveAdmin("admin_clerk_2", "admin2@devine.com");
 
             assertThat(adminRepository.findByClerkId("admin_clerk_2")).isPresent();
-            assertThat(adminRepository.findByEmail("admin2@devine.com")).isPresent();
         }
 
         @Test
@@ -62,14 +61,12 @@ class AdminRepositoryTest extends CoreIntegrationTestSupport {
             Optional<Admin> byClerkId = adminRepository.findByClerkId("admin_clerk_3");
             assertThat(byClerkId).isPresent();
             assertThat(byClerkId.get().isActive()).isFalse();
-            assertThat(adminRepository.findByEmail("admin3@devine.com")).isPresent();
         }
 
         @Test
         @DisplayName("존재하지 않으면 빈 Optional을 반환한다")
         void returns_empty_when_absent() {
             assertThat(adminRepository.findByClerkId("no_such_clerk")).isEmpty();
-            assertThat(adminRepository.findByEmail("no@such.com")).isEmpty();
         }
     }
 
@@ -87,6 +84,18 @@ class AdminRepositoryTest extends CoreIntegrationTestSupport {
             assertThat(result.get().getLevel()).isEqualTo(AdminLevel.ADMIN);
             assertThat(result.get().isActive()).isTrue();
             assertThat(result.get().getGrantedBy()).isEqualTo("BOOTSTRAP");
+        }
+
+        @Test
+        @DisplayName("email이 null이어도 삽입된다 (email은 nullable)")
+        void inserts_with_null_email() {
+            assertThatCode(() ->
+                    adminRepository.insertBootstrapAdminIfAbsent("boot_clerk_null", null, "BOOTSTRAP")
+            ).doesNotThrowAnyException();
+
+            Optional<Admin> result = adminRepository.findByClerkId("boot_clerk_null");
+            assertThat(result).isPresent();
+            assertThat(result.get().getEmail()).isNull();
         }
 
         @Test
@@ -110,9 +119,9 @@ class AdminRepositoryTest extends CoreIntegrationTestSupport {
                     adminRepository.insertBootstrapAdminIfAbsent("boot_clerk_other", "shared@devine.com", "BOOTSTRAP")
             ).doesNotThrowAnyException();
 
-            // email 충돌로 두 번째는 삽입되지 않는다
+            // email 충돌로 두 번째(다른 clerk_id)는 삽입되지 않고, 첫 행은 그대로 존재한다
             assertThat(adminRepository.findByClerkId("boot_clerk_other")).isEmpty();
-            assertThat(adminRepository.findByEmail("shared@devine.com")).isPresent();
+            assertThat(adminRepository.findByClerkId("boot_clerk_3")).isPresent();
         }
     }
 }

--- a/devine-core/src/test/java/com/umc/devine/admin/repository/AdminRepositoryTest.java
+++ b/devine-core/src/test/java/com/umc/devine/admin/repository/AdminRepositoryTest.java
@@ -1,0 +1,105 @@
+package com.umc.devine.admin.repository;
+
+import com.umc.devine.admin.entity.Admin;
+import com.umc.devine.admin.enums.AdminLevel;
+import com.umc.devine.support.CoreIntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AdminRepositoryTest extends CoreIntegrationTestSupport {
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    private Admin saveAdmin(String clerkId, String email) {
+        return adminRepository.save(Admin.builder()
+                .clerkId(clerkId)
+                .email(email)
+                .build());
+    }
+
+    @Nested
+    @DisplayName("엔티티 기본값")
+    class Defaults {
+
+        @Test
+        @DisplayName("저장 시 level은 ADMIN, isActive는 true가 기본값이다")
+        void defaults_applied() {
+            // when
+            Admin saved = saveAdmin("admin_clerk_1", "admin1@devine.com");
+
+            // then
+            assertThat(saved.getLevel()).isEqualTo(AdminLevel.ADMIN);
+            assertThat(saved.isActive()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("findActiveByClerkId")
+    class FindActiveByClerkId {
+
+        @Test
+        @DisplayName("활성 관리자를 clerkId로 조회한다")
+        void returns_active_admin() {
+            // given
+            saveAdmin("admin_clerk_2", "admin2@devine.com");
+
+            // when
+            Optional<Admin> result = adminRepository.findActiveByClerkId("admin_clerk_2");
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getEmail()).isEqualTo("admin2@devine.com");
+        }
+
+        @Test
+        @DisplayName("비활성(회수) 관리자는 조회되지 않는다")
+        void ignores_deactivated_admin() {
+            // given
+            Admin admin = saveAdmin("admin_clerk_3", "admin3@devine.com");
+            admin.deactivate();
+            adminRepository.save(admin);
+
+            // when
+            Optional<Admin> result = adminRepository.findActiveByClerkId("admin_clerk_3");
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 clerkId면 빈 Optional을 반환한다")
+        void returns_empty_when_absent() {
+            // when
+            Optional<Admin> result = adminRepository.findActiveByClerkId("no_such_clerk");
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findActiveByEmail")
+    class FindActiveByEmail {
+
+        @Test
+        @DisplayName("활성 관리자를 email로 조회한다 (부트스트랩용)")
+        void returns_active_admin_by_email() {
+            // given
+            saveAdmin("admin_clerk_4", "admin4@devine.com");
+
+            // when
+            Optional<Admin> result = adminRepository.findActiveByEmail("admin4@devine.com");
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getClerkId()).isEqualTo("admin_clerk_4");
+        }
+    }
+}

--- a/docs/admin-integration-guide.md
+++ b/docs/admin-integration-guide.md
@@ -1,0 +1,226 @@
+# 관리자(Admin) 기능 연동 가이드
+
+관리자 페이지용 백엔드 기능을 개발할 때 기존 관리자 인증/인가 골격에 연동하는 방법을 설명합니다.
+
+> 일반 사용자 인증은 [auth-integration-guide.md](./auth-integration-guide.md)를 참고하세요. 이 문서는 **관리자 전용(`/admin/v1/**`)** 기능에 한정합니다.
+
+---
+
+## 핵심 개념 (먼저 읽어주세요)
+
+- 관리자도 **일반 사용자와 동일하게 Clerk로 로그인**합니다. 별도 로그인 API가 없습니다. 프론트가 Clerk 세션 토큰(JWT)을 `Authorization: Bearer <token>`으로 보내면 백엔드가 검증합니다.
+- **인증은 공유, 인가만 분리**됩니다. `/admin/v1/**` 경로는 별도 `SecurityFilterChain`이 담당하며 **`ROLE_ADMIN`을 요구**합니다.
+- **"누가 관리자인가"는 오직 `clerk_id`(JWT의 `sub`, 위조 불가)로 판정**합니다. 이메일 등 다른 클레임에 권한을 의존시키지 않습니다.
+- 따라서 **관리자 기능 개발자는 인증/인가를 신경 쓸 필요가 없습니다.** `/admin/v1/**` 아래에 컨트롤러를 만들면 자동으로 관리자만 접근할 수 있습니다.
+
+---
+
+## 빠른 시작 — 새 관리자 API 추가
+
+`/admin/v1/**` 아래 컨트롤러를 만들면 **별도 설정 없이 자동으로 `ROLE_ADMIN`이 강제**됩니다(관리자 체인이 `/admin/**`를 담당).
+
+```java
+package com.umc.devine.admin.member.controller; // com.umc.devine.admin.<도메인>.controller
+
+import com.umc.devine.admin.auth.security.AdminPrincipal;
+import com.umc.devine.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/v1/members") // 반드시 /admin/v1/ 로 시작
+public class AdminMemberController {
+
+    private final AdminMemberService adminMemberService;
+
+    @GetMapping
+    public ApiResponse<AdminMemberResDTO.ListDTO> getMembers(
+            @AuthenticationPrincipal AdminPrincipal admin // 현재 관리자 정보
+    ) {
+        // 여기 도달했다는 것은 이미 ROLE_ADMIN이 검증됐다는 뜻
+        String actorClerkId = admin.getClerkId();
+        return ApiResponse.onSuccess(AdminMemberSuccessCode.LIST_OK, adminMemberService.getMembers());
+    }
+}
+```
+
+- **경로가 `/admin/v1/**`가 아니면** 관리자 체인이 아니라 일반 사용자 체인이 처리하므로 `ROLE_ADMIN`이 걸리지 않습니다. 반드시 접두사를 지키세요.
+- 관리자 체인은 `/admin/v1/**` 아래 **모든 요청에 `hasRole("ADMIN")`**을 적용합니다. 별도의 `@PreAuthorize`는 필요 없습니다.
+
+---
+
+## 패키지 / 경로 컨벤션
+
+| 구분 | 위치 | 예시 |
+|------|------|------|
+| URL | `/admin/v1/<도메인>` | `/admin/v1/members`, `/admin/v1/reports` |
+| 컨트롤러/서비스/DTO | `devine-api` · `com.umc.devine.admin.<도메인>.*` | `com.umc.devine.admin.member.controller` |
+| 엔티티/리포지토리 | `devine-core` · `com.umc.devine.admin.<도메인>.*` | `com.umc.devine.admin.entity.Admin` |
+| Swagger 문서 인터페이스 | 컨트롤러와 같은 패키지 | `AdminMemberControllerDocs` |
+| 성공 코드 enum | `com.umc.devine.admin.<도메인>.exception.code` | `AdminMemberSuccessCode` |
+
+기존 도메인(`com.umc.devine.domain.*`)과 **분리된 `com.umc.devine.admin.*` 트리**를 사용합니다.
+
+---
+
+## AdminPrincipal 구조
+
+관리자 컨트롤러에서 `@AuthenticationPrincipal AdminPrincipal`로 현재 관리자 정보를 받습니다.
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `clerkId` | String | 관리자 Clerk 사용자 ID (`user_xxx`). **판정 기준이자 로그 주체** |
+| `email` | String | 이메일 (nullable — 토큰에 email 클레임이 없으면 null) |
+| `name` | String | 이름 (nullable) |
+| `imageUrl` | String | 프로필 이미지 URL (nullable) |
+| `level` | `AdminLevel` | 관리자 권한 레벨 (현재 `ADMIN` 단일) |
+
+```java
+String clerkId = admin.getClerkId();
+AdminLevel level = admin.getLevel();
+```
+
+> 관리자에 연결된 `Member` 정보가 필요하면 `memberRepository.findByClerkId(clerkId)`로 조회하세요. (관리자 계정과 일반 회원은 별개일 수 있으므로 존재하지 않을 수 있습니다.)
+
+---
+
+## 인증/인가 동작 방식 (내부)
+
+```
+요청 → Clerk JWT 검증(공통)
+     ├─ /admin/v1/**  → [Admin Chain, @Order(1)]  ROLE_ADMIN 필요 → 아니면 403
+     └─ 그 외          → [기존 Chain,  @Order(2)]  ROLE_USER
+```
+
+- **`AdminJwtAuthenticationConverter`**: JWT 검증 후 `AdminAuthorizationService.resolveAdmin(clerkId, email)`로 관리자 여부 판정 → 관리자면 `ROLE_ADMIN` 부여 + `AdminPrincipal` 세팅.
+- **`AdminAuthorizationService`**: `clerk_id`로 `admin` 테이블 조회. 활성 관리자면 인가, 비활성(회수)이면 거절. 부트스트랩 대상이면 최초 접근 시 자동 등록(seeding).
+- 관리자 기능 개발자는 이 클래스들을 **수정할 필요가 없습니다.** 컨트롤러만 추가하면 됩니다.
+
+---
+
+## 응답 / 에러 포맷
+
+### 성공 응답
+
+기존 `ApiResponse` + `BaseSuccessCode`를 그대로 사용합니다.
+
+```java
+public enum AdminMemberSuccessCode implements BaseSuccessCode {
+    LIST_OK(HttpStatus.OK, "ADMIN_MEMBER200_1", "관리자 회원 목록을 조회했습니다.");
+    // ...
+}
+
+return ApiResponse.onSuccess(AdminMemberSuccessCode.LIST_OK, result);
+```
+
+```json
+{ "isSuccess": true, "code": "ADMIN_MEMBER200_1", "message": "...", "result": { ... } }
+```
+
+### 인증/인가 실패 (자동 처리)
+
+| 상황 | 상태 | 응답 body |
+|------|------|-----------|
+| 토큰 없음/무효 | **401** | `{ "isSuccess": false, "code": "AUTH401_1", "message": "인증이 필요합니다." }` |
+| 관리자 아님(ROLE_ADMIN 없음) | **403** | `{ "isSuccess": false, "code": "AUTH403_1", "message": "요청이 거부되었습니다." }` |
+
+- 403 메시지는 **관리자 존재 여부를 노출하지 않는 일반 메시지**로 통일돼 있습니다(`AdminAccessDeniedHandler`).
+- 이 두 경우는 프레임워크가 자동 처리하므로 컨트롤러에서 다룰 필요가 없습니다.
+
+---
+
+## 감사 로그 (자동)
+
+`/admin/v1/**` 접근은 자동으로 구조화 로그에 기록됩니다. 별도 코드가 필요 없습니다.
+
+- 인가된 접근: `[ADMIN-ACCESS] clerkId=user_xxx method=GET path=/admin/v1/members status=200`
+- 거절된 접근(403): `[ADMIN-ACCESS-DENIED] clerkId=... method=... path=... status=403`
+
+> 관리자가 **데이터를 변경하는 기능**(회원 정지/삭제, 결제 취소 등)을 추가할 때는, 되돌릴 수 없는 행위에 한해 **DB 감사 테이블** 도입을 검토하세요(현재는 구조화 로그만 사용).
+
+---
+
+## 관리자 계정 관리
+
+### 관리자 등록 (부트스트랩)
+
+관리자 계정 CRUD API는 아직 없습니다. 최초/추가 관리자는 **환경변수 부트스트랩**으로 등록합니다.
+
+1. 대상자가 Clerk로 로그인 후 `/admin/v1/auth/me` 호출 → 403이 나면 서버 로그의 `[ADMIN-ACCESS-DENIED] clerkId=user_xxx`에서 `user_xxx` 확인 (또는 Clerk Dashboard → Users → User ID).
+2. `.env`에 `ADMIN_BOOTSTRAP_CLERK_IDS=user_xxx,user_yyy` (콤마 구분) 설정 후 재시작.
+3. 대상자가 다시 `/admin/v1/**` 접근 시 `admin` 테이블에 자동 등록되고 이후 정상 동작.
+
+### 관리자 회수
+
+`admin` 테이블의 해당 행 `is_active=false`로 변경(회수). **동시에 `ADMIN_BOOTSTRAP_CLERK_IDS`에서도 해당 clerk_id를 제거**하세요(회수 우선 정책상 목록에 남아도 재활성화되진 않지만, 목록 정리로 백도어를 최소화).
+
+### 권한 레벨 확장
+
+현재 `AdminLevel`은 `ADMIN` 단일입니다. 다단계가 필요하면 `AdminLevel` enum과 마이그레이션의 `admin_level_check` 제약을 **함께** 갱신하세요(둘 중 하나만 바꾸면 CHECK 위반 → 트랜잭션 abort).
+
+---
+
+## 테스트 작성법
+
+관리자 컨트롤러 통합 테스트는 `ControllerIntegrationTestSupport`를 상속하고, `AdminPrincipal` + `ROLE_ADMIN` 인증을 주입합니다.
+
+```java
+class AdminMemberControllerTest extends ControllerIntegrationTestSupport {
+
+    private Authentication adminAuth() {
+        AdminPrincipal principal = AdminPrincipal.builder()
+                .clerkId("admin_clerk_1").email("admin@devine.com")
+                .name("관리자").level(AdminLevel.ADMIN)
+                .build();
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+    }
+
+    @Test
+    void 관리자_목록_조회() throws Exception {
+        mockMvc.perform(get("/admin/v1/members")
+                        .with(authentication(adminAuth())))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 비관리자_403() throws Exception {
+        Authentication userAuth = new UsernamePasswordAuthenticationToken(
+                new ClerkPrincipal("user_1", "u@d.com", "u", null), null, List.of());
+        mockMvc.perform(get("/admin/v1/members").with(authentication(userAuth)))
+                .andExpect(status().isForbidden());
+    }
+}
+```
+
+- `.with(authentication(...))`는 SecurityContext에 주체를 직접 주입하므로, 실제 Clerk 토큰 없이 인가 규칙을 검증할 수 있습니다.
+- 참고 예시: `AdminAuthControllerTest`(관리자 200 / 비관리자 403 / 미인증 401).
+
+---
+
+## 자주 묻는 질문 (FAQ)
+
+**Q. 새 관리자 API에 권한 체크 코드를 넣어야 하나요?**
+아니요. `/admin/v1/**` 경로면 자동으로 `ROLE_ADMIN`이 강제됩니다.
+
+**Q. `AdminPrincipal`이 null로 들어와요.**
+경로가 `/admin/v1/**`인지 확인하세요. 그 외 경로는 일반 사용자 체인이 처리해 `ClerkPrincipal`이 주입됩니다.
+
+**Q. 관리자용 공개(비인증) 엔드포인트가 필요해요.**
+관리자 체인은 `/admin/v1/**` 전체에 `hasRole("ADMIN")`을 적용합니다. 공개가 꼭 필요하면 `ApiSecurityConfig`의 관리자 체인에 `permitAll` 매처를 추가해야 합니다(원칙적으로 지양).
+
+**Q. 관리자의 이메일/이름이 null이에요.**
+Clerk 기본 세션 토큰에는 email/name 클레임이 없습니다. 필요하면 Clerk 대시보드에서 세션 토큰에 클레임을 추가하세요. 단 **관리자 판정은 email과 무관**하므로(clerk_id 기준) 관리자 동작 자체엔 영향이 없습니다.
+
+**Q. 관리자에 연결된 회원 정보가 필요해요.**
+`memberRepository.findByClerkId(admin.getClerkId())`로 조회하세요(없을 수 있음).
+
+---
+
+## 참고 자료
+
+- 일반 인증 연동: `docs/auth-integration-guide.md`
+- 예시 구현: `com.umc.devine.admin.auth.*` (컨트롤러/서비스/시큐리티/DTO)
+- 보안 설정: `com.umc.devine.global.config.ApiSecurityConfig` (`adminSecurityFilterChain`)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- issue #294

## #️⃣ 작업 내용

관리자 로그인의 **인증/인가 골격**을 추가했습니다.

- 관리자도 기존 **Clerk JWT로 인증**하고, `/admin/v1/**` 전용 `SecurityFilterChain(@Order(1))`에서 `ROLE_ADMIN`만 인가 → **인증은 공유, 인가만 분리**
- **"누가 관리자인가"는 `clerk_id`(JWT의 sub, 위조 불가)로만 판정.** `admin` 테이블 + `ADMIN_BOOTSTRAP_CLERK_IDS` 환경변수로 최초 관리자 lazy seeding
- `GET /admin/v1/auth/me` (권한 레벨 포함) 추가
- 관리자 접근 **감사 로그**(구조화 로그) + 403은 관리자 존재를 노출하지 않는 일반 메시지
- 부트스트랩 seeding의 UNIQUE 위반(→500)·회수 불가 문제를 **ON CONFLICT 멱등 upsert + 회수 우선 판정**으로 해결
- 팀원용 **연동 가이드** 추가 (`docs/admin-integration-guide.md`)

### ⚙️ 관리자 등록에 필요한 설정
- `.env`에 `ADMIN_BOOTSTRAP_CLERK_IDS=user_xxx` (최초 관리자의 Clerk user id) 설정
- 관리자용 Clerk 세션 토큰 커스터마이즈는 **불필요** (clerk_id만 신뢰)

## #️⃣ 테스트 결과

- 전체 테스트 스위트 통과 (`./gradlew test`)
- 신규 테스트
  - `AdminAuthorizationServiceTest` (단위): 기존 관리자 / 회수 / 부트스트랩 / 비관리자 판정
  - `AdminAuthorizationServiceIntegrationTest` (실 Postgres): seeding, email 없이 등록, 회수 재접근 시 500 방지
  - `AdminRepositoryTest`: 조회, ON CONFLICT 멱등성(clerk_id·email 충돌), null email 삽입
  - `AdminAuthControllerTest`: 관리자 200 / 비관리자 403 / 미인증 401
- 실 Postgres에서 Flyway 마이그레이션 적용 및 애플리케이션 기동 확인

## 관리자 clerk_id 환경 변수에 입력 안했을 경우 
<img width="2824" height="1550" alt="image" src="https://github.com/user-attachments/assets/0c9cea5d-c601-4f63-8d0c-14530e57c87a" />

## 관리자 clerk_id 환경 변수 입력 이후 정상 작동 확인
<img width="2824" height="1550" alt="image" src="https://github.com/user-attachments/assets/a8087cab-02e1-4f29-bd0d-0d3a9012e2af" />


## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

- 부트스트랩 판정을 email이 아닌 **clerk_id(sub)** 기준으로 둔 보안 설계가 적절한지
- `AdminAuthorizationService`의 **회수 우선 + ON CONFLICT 멱등 seeding** 로직

## 📎 참고 자료 (선택)

- 관리자 기능 연동 가이드: `docs/admin-integration-guide.md`
