### PR TITLE
[FIX/REALTIME] 채팅방 재입장 시 목록 lastMessage·안읽음·정렬이 leftAt 반영하도록 수정

### DIFF
--- a/devine-core/src/main/java/com/umc/devine/domain/chat/repository/ChatMessageRepository.java
+++ b/devine-core/src/main/java/com/umc/devine/domain/chat/repository/ChatMessageRepository.java
@@ -57,8 +57,10 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             WHERE cm.sender.id != :memberId
               AND cm.isRead = false
               AND (
-                (cr.member1.id = :memberId AND cr.member1Left = false)
-                OR (cr.member2.id = :memberId AND cr.member2Left = false)
+                (cr.member1.id = :memberId AND cr.member1Left = false
+                    AND (cr.member1LeftAt IS NULL OR cm.createdAt > cr.member1LeftAt))
+                OR (cr.member2.id = :memberId AND cr.member2Left = false
+                    AND (cr.member2LeftAt IS NULL OR cm.createdAt > cr.member2LeftAt))
               )
             """)
     long countRoomsWithUnreadMessages(@Param("memberId") Long memberId);
@@ -66,9 +68,16 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     @Query("""
             SELECT cm.chatRoom.id, COUNT(cm)
             FROM ChatMessage cm
-            WHERE cm.chatRoom.id IN :roomIds
+            JOIN cm.chatRoom cr
+            WHERE cr.id IN :roomIds
               AND cm.sender.id != :memberId
               AND cm.isRead = false
+              AND (
+                (cr.member1.id = :memberId
+                    AND (cr.member1LeftAt IS NULL OR cm.createdAt > cr.member1LeftAt))
+                OR (cr.member2.id = :memberId
+                    AND (cr.member2LeftAt IS NULL OR cm.createdAt > cr.member2LeftAt))
+              )
             GROUP BY cm.chatRoom.id
             """)
     List<Object[]> countUnreadPerRoom(
@@ -83,9 +92,19 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             JOIN FETCH cm.sender
             WHERE cm.id IN (
                 SELECT MAX(cm2.id) FROM ChatMessage cm2
-                WHERE cm2.chatRoom.id IN :roomIds
+                JOIN cm2.chatRoom cr2
+                WHERE cr2.id IN :roomIds
+                  AND (
+                    (cr2.member1.id = :memberId
+                        AND (cr2.member1LeftAt IS NULL OR cm2.createdAt > cr2.member1LeftAt))
+                    OR (cr2.member2.id = :memberId
+                        AND (cr2.member2LeftAt IS NULL OR cm2.createdAt > cr2.member2LeftAt))
+                  )
                 GROUP BY cm2.chatRoom.id
             )
             """)
-    List<ChatMessage> findLastMessagesByRoomIds(@Param("roomIds") List<Long> roomIds);
+    List<ChatMessage> findLastMessagesByRoomIds(
+            @Param("roomIds") List<Long> roomIds,
+            @Param("memberId") Long memberId
+    );
 }

--- a/devine-core/src/main/java/com/umc/devine/domain/chat/repository/ChatRoomRepository.java
+++ b/devine-core/src/main/java/com/umc/devine/domain/chat/repository/ChatRoomRepository.java
@@ -16,6 +16,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             SELECT cr.chat_room_id, COALESCE(MAX(cm.created_at), cr.created_at) AS last_activity
             FROM chat_room cr
             LEFT JOIN chat_message cm ON cm.chat_room_id = cr.chat_room_id
+                AND (
+                    (cr.member1_id = :memberId AND (cr.member1_left_at IS NULL OR cm.created_at > cr.member1_left_at))
+                    OR (cr.member2_id = :memberId AND (cr.member2_left_at IS NULL OR cm.created_at > cr.member2_left_at))
+                )
             WHERE (cr.member1_id = :memberId AND cr.member1_left = false)
                OR (cr.member2_id = :memberId AND cr.member2_left = false)
             GROUP BY cr.chat_room_id

--- a/devine-core/src/test/java/com/umc/devine/domain/chat/repository/ChatMessageRepositoryTest.java
+++ b/devine-core/src/test/java/com/umc/devine/domain/chat/repository/ChatMessageRepositoryTest.java
@@ -1,0 +1,225 @@
+package com.umc.devine.domain.chat.repository;
+
+import com.umc.devine.domain.chat.entity.ChatMessage;
+import com.umc.devine.domain.chat.entity.ChatRoom;
+import com.umc.devine.domain.member.entity.Member;
+import com.umc.devine.domain.member.enums.MemberMainType;
+import com.umc.devine.domain.member.enums.MemberStatus;
+import com.umc.devine.domain.member.repository.MemberRepository;
+import com.umc.devine.support.CoreIntegrationTestSupport;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 채팅방 나가기 후 재연락(방 재사용) 시, 나간 유저 기준으로 방 목록의
+ * lastMessage / 안읽음 수가 leftAt 이후 메시지만 반영하는지 검증한다. (#312)
+ */
+class ChatMessageRepositoryTest extends CoreIntegrationTestSupport {
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    private static final LocalDateTime T_OLD = LocalDateTime.of(2026, 1, 1, 10, 0);
+    private static final LocalDateTime T_LEFT = LocalDateTime.of(2026, 1, 1, 11, 0);
+    private static final LocalDateTime T_NEW = LocalDateTime.of(2026, 1, 1, 12, 0);
+
+    private Member memberA;
+    private Member memberB;
+    private ChatRoom room;
+
+    @BeforeEach
+    void setUp() {
+        memberA = saveMember();
+        memberB = saveMember();
+        // member1 = A(나갔다 재입장), member2 = B(그대로)
+        room = chatRoomRepository.save(ChatRoom.builder()
+                .member1(memberA)
+                .member2(memberB)
+                .build());
+    }
+
+    private Member saveMember() {
+        int n = SEQ.incrementAndGet();
+        return memberRepository.save(Member.builder()
+                .clerkId("clerk_" + n)
+                .name("member" + n)
+                .nickname("nick_" + n)
+                .mainType(MemberMainType.DEVELOPER)
+                .disclosure(true)
+                .used(MemberStatus.ACTIVE)
+                .build());
+    }
+
+    private ChatMessage saveMessage(Member sender, String content, boolean read, LocalDateTime createdAt) {
+        ChatMessage msg = ChatMessage.builder()
+                .chatRoom(room)
+                .sender(sender)
+                .content(content)
+                .isRead(read)
+                .build();
+        chatMessageRepository.save(msg);
+        em.flush();
+        jdbcTemplate.update(
+                "UPDATE chat_message SET created_at = ? WHERE chat_message_id = ?",
+                createdAt, msg.getId());
+        return msg;
+    }
+
+    /** A(member1)가 leftAt 시점에 나갔다가 재입장한 상태로 설정한다. */
+    private void memberALeftAndRejoined(LocalDateTime leftAt) {
+        jdbcTemplate.update(
+                "UPDATE chat_room SET member1_left = false, member1_left_at = ? WHERE chat_room_id = ?",
+                leftAt, room.getId());
+        em.clear();
+    }
+
+    @Nested
+    @DisplayName("findLastMessagesByRoomIds - 나간 유저 기준 lastMessage 리셋")
+    class FindLastMessages {
+
+        @Test
+        @DisplayName("나갔다 재입장한 유저에게는 leftAt 이전 메시지가 lastMessage로 잡히지 않는다")
+        void excludesMessagesBeforeLeft_forLeftMember() {
+            // given: 나가기 전 메시지만 존재, A가 나갔다 재입장
+            saveMessage(memberB, "old", true, T_OLD);
+            memberALeftAndRejoined(T_LEFT);
+
+            // when
+            List<ChatMessage> result = chatMessageRepository.findLastMessagesByRoomIds(
+                    List.of(room.getId()), memberA.getId());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("나가지 않은 상대방에게는 이전 메시지가 그대로 lastMessage로 잡힌다")
+        void keepsMessages_forNonLeftMember() {
+            // given
+            saveMessage(memberB, "old", true, T_OLD);
+            memberALeftAndRejoined(T_LEFT);
+
+            // when
+            List<ChatMessage> result = chatMessageRepository.findLastMessagesByRoomIds(
+                    List.of(room.getId()), memberB.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getContent()).isEqualTo("old");
+        }
+
+        @Test
+        @DisplayName("재입장 후 새 메시지가 오면 그 메시지가 lastMessage로 잡힌다")
+        void showsMessagesAfterRejoin() {
+            // given
+            saveMessage(memberB, "old", true, T_OLD);
+            memberALeftAndRejoined(T_LEFT);
+            saveMessage(memberB, "new", false, T_NEW);
+
+            // when
+            List<ChatMessage> result = chatMessageRepository.findLastMessagesByRoomIds(
+                    List.of(room.getId()), memberA.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getContent()).isEqualTo("new");
+        }
+    }
+
+    @Nested
+    @DisplayName("countUnreadPerRoom - 나간 유저 기준 안읽음 카운트")
+    class CountUnreadPerRoom {
+
+        @Test
+        @DisplayName("leftAt 이전 안읽음 메시지는 카운트하지 않는다")
+        void excludesUnreadBeforeLeft() {
+            // given: 나가기 전 안읽음 메시지만 존재
+            saveMessage(memberB, "old-unread", false, T_OLD);
+            memberALeftAndRejoined(T_LEFT);
+
+            // when
+            List<Object[]> result = chatMessageRepository.countUnreadPerRoom(
+                    List.of(room.getId()), memberA.getId());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("재입장 후 도착한 안읽음 메시지는 카운트한다")
+        void countsUnreadAfterRejoin() {
+            // given
+            saveMessage(memberB, "old-unread", false, T_OLD);
+            memberALeftAndRejoined(T_LEFT);
+            saveMessage(memberB, "new-unread", false, T_NEW);
+
+            // when
+            List<Object[]> result = chatMessageRepository.countUnreadPerRoom(
+                    List.of(room.getId()), memberA.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(((Number) result.get(0)[1]).longValue()).isEqualTo(1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("countRoomsWithUnreadMessages - 나간 유저 기준 전체 안읽음 방 수")
+    class CountRoomsWithUnread {
+
+        @Test
+        @DisplayName("leftAt 이전 안읽음만 있으면 안읽음 방으로 세지 않는다")
+        void excludesRoomWithOnlyPreLeftUnread() {
+            // given
+            saveMessage(memberB, "old-unread", false, T_OLD);
+            memberALeftAndRejoined(T_LEFT);
+
+            // when
+            long count = chatMessageRepository.countRoomsWithUnreadMessages(memberA.getId());
+
+            // then
+            assertThat(count).isZero();
+        }
+
+        @Test
+        @DisplayName("재입장 후 안읽음 메시지가 있으면 안읽음 방으로 센다")
+        void countsRoomWithPostRejoinUnread() {
+            // given
+            saveMessage(memberB, "old-unread", false, T_OLD);
+            memberALeftAndRejoined(T_LEFT);
+            saveMessage(memberB, "new-unread", false, T_NEW);
+
+            // when
+            long count = chatMessageRepository.countRoomsWithUnreadMessages(memberA.getId());
+
+            // then
+            assertThat(count).isEqualTo(1L);
+        }
+    }
+}

--- a/devine-core/src/test/java/com/umc/devine/domain/chat/repository/ChatRoomRepositoryTest.java
+++ b/devine-core/src/test/java/com/umc/devine/domain/chat/repository/ChatRoomRepositoryTest.java
@@ -1,0 +1,144 @@
+package com.umc.devine.domain.chat.repository;
+
+import com.umc.devine.domain.chat.entity.ChatMessage;
+import com.umc.devine.domain.chat.entity.ChatRoom;
+import com.umc.devine.domain.member.entity.Member;
+import com.umc.devine.domain.member.enums.MemberMainType;
+import com.umc.devine.domain.member.enums.MemberStatus;
+import com.umc.devine.domain.member.repository.MemberRepository;
+import com.umc.devine.support.CoreIntegrationTestSupport;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 방 목록 정렬/lastMessageAt을 결정하는 last_activity가
+ * 나간 유저 기준 leftAt 이후 메시지만 반영하는지 검증한다. (#312)
+ */
+class ChatRoomRepositoryTest extends CoreIntegrationTestSupport {
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private static final AtomicInteger SEQ = new AtomicInteger();
+
+    private static final LocalDateTime T_ROOM_CREATED = LocalDateTime.of(2026, 1, 1, 9, 0);
+    private static final LocalDateTime T_OLD = LocalDateTime.of(2026, 1, 1, 10, 0);
+    private static final LocalDateTime T_LEFT = LocalDateTime.of(2026, 1, 1, 11, 0);
+    private static final LocalDateTime T_NEW = LocalDateTime.of(2026, 1, 1, 12, 0);
+
+    private Member memberA;
+    private Member memberB;
+    private ChatRoom room;
+
+    @BeforeEach
+    void setUp() {
+        memberA = saveMember();
+        memberB = saveMember();
+        room = chatRoomRepository.save(ChatRoom.builder()
+                .member1(memberA)
+                .member2(memberB)
+                .build());
+        em.flush();
+        jdbcTemplate.update(
+                "UPDATE chat_room SET created_at = ? WHERE chat_room_id = ?",
+                T_ROOM_CREATED, room.getId());
+    }
+
+    private Member saveMember() {
+        int n = SEQ.incrementAndGet();
+        return memberRepository.save(Member.builder()
+                .clerkId("clerk_room_" + n)
+                .name("member" + n)
+                .nickname("nick_room_" + n)
+                .mainType(MemberMainType.DEVELOPER)
+                .disclosure(true)
+                .used(MemberStatus.ACTIVE)
+                .build());
+    }
+
+    private void saveMessage(Member sender, String content, LocalDateTime createdAt) {
+        ChatMessage msg = ChatMessage.builder()
+                .chatRoom(room)
+                .sender(sender)
+                .content(content)
+                .isRead(true)
+                .build();
+        chatMessageRepository.save(msg);
+        em.flush();
+        jdbcTemplate.update(
+                "UPDATE chat_message SET created_at = ? WHERE chat_message_id = ?",
+                createdAt, msg.getId());
+    }
+
+    private void memberALeftAndRejoined(LocalDateTime leftAt) {
+        jdbcTemplate.update(
+                "UPDATE chat_room SET member1_left = false, member1_left_at = ? WHERE chat_room_id = ?",
+                leftAt, room.getId());
+        em.clear();
+    }
+
+    private LocalDateTime lastActivityOf(Member member) {
+        List<Object[]> rows = chatRoomRepository.findActiveRoomIdsSortedByActivity(member.getId());
+        assertThat(rows).hasSize(1);
+        Object raw = rows.get(0)[1];
+        return raw instanceof Timestamp ts ? ts.toLocalDateTime() : (LocalDateTime) raw;
+    }
+
+    @Test
+    @DisplayName("나갔다 재입장한 유저 기준으로 leftAt 이전 메시지는 last_activity에 반영되지 않고 방 생성시각으로 폴백한다")
+    void lastActivityExcludesPreLeftMessage() {
+        // given: 나가기 전 메시지만 존재, A가 나갔다 재입장
+        saveMessage(memberB, "old", T_OLD);
+        memberALeftAndRejoined(T_LEFT);
+
+        // when / then: 이전 메시지 시각(T_OLD)이 아니라 방 생성시각으로 폴백
+        assertThat(lastActivityOf(memberA)).isEqualTo(T_ROOM_CREATED);
+    }
+
+    @Test
+    @DisplayName("재입장 후 새 메시지가 오면 그 시각이 last_activity가 된다")
+    void lastActivityReflectsPostRejoinMessage() {
+        // given
+        saveMessage(memberB, "old", T_OLD);
+        memberALeftAndRejoined(T_LEFT);
+        saveMessage(memberB, "new", T_NEW);
+
+        // when / then
+        assertThat(lastActivityOf(memberA)).isEqualTo(T_NEW);
+    }
+
+    @Test
+    @DisplayName("나가지 않은 상대방에게는 이전 메시지 시각이 그대로 last_activity가 된다")
+    void lastActivityKeepsMessageForNonLeftMember() {
+        // given
+        saveMessage(memberB, "old", T_OLD);
+        memberALeftAndRejoined(T_LEFT);
+
+        // when / then
+        assertThat(lastActivityOf(memberB)).isEqualTo(T_OLD);
+    }
+}

--- a/devine-realtime/src/main/java/com/umc/devine/domain/chat/service/query/ChatQueryServiceImpl.java
+++ b/devine-realtime/src/main/java/com/umc/devine/domain/chat/service/query/ChatQueryServiceImpl.java
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.Function;
@@ -40,12 +39,6 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                 .map(row -> ((Number) row[0]).longValue())
                 .toList();
 
-        Map<Long, LocalDateTime> lastActivityMap = activeRooms.stream()
-                .collect(Collectors.toMap(
-                        row -> ((Number) row[0]).longValue(),
-                        row -> row[1] instanceof Timestamp ts ? ts.toLocalDateTime() : (LocalDateTime) row[1]
-                ));
-
         Map<Long, ChatRoom> roomMap = chatRoomRepository.findRoomsWithMembersByIds(roomIds).stream()
                 .collect(Collectors.toMap(ChatRoom::getId, Function.identity()));
 
@@ -64,7 +57,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                     return ChatConverter.toChatRoomDetail(
                             room, memberId,
                             lastMsg != null ? lastMsg.getContent() : null,
-                            lastActivityMap.get(roomId),
+                            lastMsg != null ? lastMsg.getCreatedAt() : null,
                             unreadMap.getOrDefault(roomId, 0L)
                     );
                 })

--- a/devine-realtime/src/main/java/com/umc/devine/domain/chat/service/query/ChatQueryServiceImpl.java
+++ b/devine-realtime/src/main/java/com/umc/devine/domain/chat/service/query/ChatQueryServiceImpl.java
@@ -53,7 +53,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         chatMessageRepository.countUnreadPerRoom(roomIds, memberId)
                 .forEach(row -> unreadMap.put((Long) row[0], (Long) row[1]));
 
-        Map<Long, ChatMessage> lastMsgMap = chatMessageRepository.findLastMessagesByRoomIds(roomIds).stream()
+        Map<Long, ChatMessage> lastMsgMap = chatMessageRepository.findLastMessagesByRoomIds(roomIds, memberId).stream()
                 .collect(Collectors.toMap(cm -> cm.getChatRoom().getId(), Function.identity()));
 
         List<ChatResDTO.ChatRoomDetail> rooms = roomIds.stream()

--- a/devine-realtime/src/test/java/com/umc/devine/domain/chat/service/query/ChatQueryServiceImplTest.java
+++ b/devine-realtime/src/test/java/com/umc/devine/domain/chat/service/query/ChatQueryServiceImplTest.java
@@ -1,0 +1,119 @@
+package com.umc.devine.domain.chat.service.query;
+
+import com.umc.devine.domain.chat.dto.ChatResDTO;
+import com.umc.devine.domain.chat.entity.ChatMessage;
+import com.umc.devine.domain.chat.entity.ChatRoom;
+import com.umc.devine.domain.chat.repository.ChatMessageRepository;
+import com.umc.devine.domain.chat.repository.ChatRoomRepository;
+import com.umc.devine.domain.member.entity.Member;
+import com.umc.devine.domain.member.enums.MemberMainType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatQueryServiceImpl.getRoomList - lastMessage/lastMessageAt 짝 처리")
+class ChatQueryServiceImplTest {
+
+    private static final Long ME = 1L;
+    private static final Long OTHER = 2L;
+    private static final Long ROOM_WITH_MSG = 10L;
+    private static final Long ROOM_EMPTY = 20L;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @InjectMocks
+    private ChatQueryServiceImpl chatQueryService;
+
+    private Member member(Long id, MemberMainType type) {
+        return Member.builder()
+                .id(id)
+                .clerkId("clerk-" + id)
+                .nickname("nick-" + id)
+                .mainType(type)
+                .build();
+    }
+
+    private ChatRoom room(Long id, Member m1, Member m2) {
+        return ChatRoom.builder().id(id).member1(m1).member2(m2).build();
+    }
+
+    private ChatMessage message(ChatRoom room, Member sender, String content, LocalDateTime createdAt) {
+        ChatMessage msg = ChatMessage.builder()
+                .chatRoom(room)
+                .sender(sender)
+                .content(content)
+                .build();
+        ReflectionTestUtils.setField(msg, "createdAt", createdAt);
+        return msg;
+    }
+
+    @Test
+    @DisplayName("마지막 메시지가 있는 방은 그 메시지의 시각이 lastMessageAt이 된다")
+    void lastMessageAtMatchesLastMessage() {
+        Member me = member(ME, MemberMainType.DEVELOPER);
+        Member other = member(OTHER, MemberMainType.PM);
+        ChatRoom room = room(ROOM_WITH_MSG, me, other);
+        LocalDateTime msgAt = LocalDateTime.of(2026, 7, 25, 3, 0);
+        ChatMessage lastMsg = message(room, other, "안녕", msgAt);
+
+        // row[1](last_activity)은 이제 표시에 쓰이지 않으므로 null이어도 무방함을 확인
+        when(chatRoomRepository.findActiveRoomIdsSortedByActivity(ME))
+                .thenReturn(List.<Object[]>of(new Object[]{ROOM_WITH_MSG, null}));
+        when(chatRoomRepository.findRoomsWithMembersByIds(anyList()))
+                .thenReturn(List.of(room));
+        when(chatMessageRepository.countUnreadPerRoom(anyList(), eq(ME)))
+                .thenReturn(List.<Object[]>of(new Object[]{ROOM_WITH_MSG, 2L}));
+        when(chatMessageRepository.findLastMessagesByRoomIds(anyList(), eq(ME)))
+                .thenReturn(List.of(lastMsg));
+
+        ChatResDTO.ChatRoomList result = chatQueryService.getRoomList(ME);
+
+        assertThat(result.rooms()).hasSize(1);
+        ChatResDTO.ChatRoomDetail detail = result.rooms().get(0);
+        assertThat(detail.lastMessage()).isEqualTo("안녕");
+        assertThat(detail.lastMessageAt()).isEqualTo(msgAt);
+        assertThat(detail.unreadCount()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("마지막 메시지가 없는 방(재입장 후 새 메시지 없음)은 lastMessage와 lastMessageAt이 모두 null이다")
+    void lastMessageAtNullWhenNoLastMessage() {
+        Member me = member(ME, MemberMainType.DEVELOPER);
+        Member other = member(OTHER, MemberMainType.PM);
+        ChatRoom emptyRoom = room(ROOM_EMPTY, me, other);
+
+        when(chatRoomRepository.findActiveRoomIdsSortedByActivity(ME))
+                .thenReturn(List.<Object[]>of(new Object[]{ROOM_EMPTY, null}));
+        when(chatRoomRepository.findRoomsWithMembersByIds(anyList()))
+                .thenReturn(List.of(emptyRoom));
+        when(chatMessageRepository.countUnreadPerRoom(anyList(), eq(ME)))
+                .thenReturn(List.of());
+        when(chatMessageRepository.findLastMessagesByRoomIds(anyList(), eq(ME)))
+                .thenReturn(List.of());
+
+        ChatResDTO.ChatRoomList result = chatQueryService.getRoomList(ME);
+
+        assertThat(result.rooms()).hasSize(1);
+        ChatResDTO.ChatRoomDetail detail = result.rooms().get(0);
+        assertThat(detail.lastMessage()).isNull();
+        assertThat(detail.lastMessageAt()).isNull();
+        assertThat(detail.unreadCount()).isEqualTo(0L);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- issue #312

## #️⃣ 작업 내용

채팅방을 나간 뒤 재연락으로 같은 방을 재사용할 때, **방 목록의 lastMessage·안읽음·정렬이 나가기 시점(`leftAt`)을 무시하고 나가기 이전 메시지까지 노출하던 문제**를 수정했습니다.

메시지 상세 조회(`getMessages`)는 이미 `createdAt > leftAt` 필터를 적용하고 있었지만, 방 목록 쪽 쿼리 3종에는 누락되어 있어 목록과 상세가 서로 다른 내용을 보여주고 있었습니다.

**1. 나간 유저 기준 `leftAt` 필터 추가** (`devine-core`)

| 쿼리 | 영향 |
|---|---|
| `ChatMessageRepository.findLastMessagesByRoomIds` | 목록의 lastMessage가 나가기 이전 메시지로 잡히던 문제. `memberId` 파라미터 추가 |
| `ChatMessageRepository.countUnreadPerRoom` | 방별 안읽음 카운트에 나가기 이전 메시지가 포함되던 문제 |
| `ChatMessageRepository.countRoomsWithUnreadMessages` | 전체 안읽음 방 수(SSE 배지)에 동일 문제 |
| `ChatRoomRepository.findActiveRoomIdsSortedByActivity` | 목록 정렬 기준 `last_activity`에 동일 문제. `LEFT JOIN` 조건에 필터 추가 |

필터는 상세 조회와 동일하게 `leftAt IS NULL OR cm.createdAt > leftAt` 술어를 사용합니다. 나가지 않은 상대방(`leftAt IS NULL`)의 뷰는 기존과 완전히 동일합니다.

**2. `lastMessageAt`을 마지막 메시지 시각과 일치시킴** (`devine-realtime`)

기존에는 `lastMessage`는 메시지 테이블에서, `lastMessageAt`은 정렬용 `last_activity`에서 각각 가져왔습니다. `last_activity`는 `COALESCE(MAX(cm.created_at), cr.created_at)`이라 메시지가 없으면 방 생성시각으로 폴백하므로, 재입장 후 새 메시지가 없는 방에서 **`lastMessage`는 null인데 `lastMessageAt`에만 값이 담기는** 불일치가 발생했습니다. 마지막 메시지의 `createdAt`을 직접 사용하도록 바꿔 두 값이 항상 짝을 이루게 했습니다.

스키마 변경 없음 — `member1_left_at` / `member2_left_at` 컬럼은 기존 마이그레이션(`V20260329120000__254_chat.sql`)에 이미 존재합니다.

## #️⃣ 테스트 결과

`./gradlew :devine-core:cleanTest :devine-core:test :devine-realtime:cleanTest :devine-realtime:test` — **12개 신규 테스트 전부 통과 (실패 0 / 에러 0)**

`ChatMessageRepositoryTest` (Testcontainers PostgreSQL, 7개)
- `findLastMessagesByRoomIds` — 나갔다 재입장한 유저에게는 leftAt 이전 메시지가 lastMessage로 잡히지 않는다 / 나가지 않은 상대방에게는 이전 메시지가 그대로 잡힌다 / 재입장 후 새 메시지가 오면 그 메시지가 잡힌다
- `countUnreadPerRoom` — leftAt 이전 안읽음은 카운트하지 않는다 / 재입장 후 도착한 안읽음은 카운트한다
- `countRoomsWithUnreadMessages` — leftAt 이전 안읽음만 있으면 안읽음 방으로 세지 않는다 / 재입장 후 안읽음이 있으면 센다

`ChatRoomRepositoryTest` (Testcontainers PostgreSQL, 3개)
- leftAt 이전 메시지는 `last_activity`에 반영되지 않고 방 생성시각으로 폴백한다 / 재입장 후 새 메시지 시각이 `last_activity`가 된다 / 나가지 않은 상대방에게는 이전 메시지 시각이 유지된다

`ChatQueryServiceImplTest` (Mockito, 2개)
- 마지막 메시지가 있는 방은 그 메시지의 시각이 `lastMessageAt`이 된다 / 마지막 메시지가 없는 방은 `lastMessage`와 `lastMessageAt`이 모두 null이다

네이티브 쿼리(`findActiveRoomIdsSortedByActivity`)도 Testcontainers 실제 PostgreSQL에서 검증했습니다.

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우) — 해당 없음
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?
  - `findLastMessagesByRoomIds` 시그니처에 `memberId`가 추가됐으나 호출처는 `ChatQueryServiceImpl` 한 곳뿐입니다.
  - 신규 필터 조건은 기존 인덱스 `idx_chat_message_room_created (chat_room_id, created_at DESC)`가 커버합니다.

## #️⃣ 리뷰 요구사항 (선택)

**1. 프론트 영향 — `lastMessageAt`이 null로 내려올 수 있습니다 ⚠️**

재입장 후 아직 새 메시지가 없는 방은 `lastMessage`, `lastMessageAt`이 **둘 다 null**로 응답됩니다. (기존에는 나가기 이전 메시지 내용과 시각이 내려갔습니다.)

이슈에 명시된 수정 방향(`나가기 → 다시 연락 → 메시지 보내기 전까지 lastMessage 비어 있음`)과 동일한 동작이며, 나간 당사자 뷰에만 적용되고 상대방 뷰는 그대로 유지된다는 요구사항도 테스트로 검증했습니다. 프론트에서 null 처리가 필요합니다.

**2. 정렬은 이번 PR 범위 밖입니다 — 별도 이슈로 분리**

위 케이스(재연락으로 방을 다시 열었지만 아직 메시지가 없는 상태)에서 정렬 키는 `COALESCE` 폴백에 따라 **방 생성시각**이 되어 목록 하단에 위치합니다. 반면 새로 만든 방은 생성시각이 현재라 상단에 뜹니다. "새 방은 위 / 재연락한 방은 아래"라는 비대칭이 남습니다.

이 케이스는 `ChatCommandServiceImpl.createOrGetRoom`의 `rejoin` 경로에서만 발생합니다. `sendMessage` 경로의 `rejoin`은 새 메시지가 즉시 생기므로 정상적으로 최상단에 위치합니다.

제대로 고치려면 `rejoined_at` 컬럼 추가(마이그레이션 + 엔티티)가 필요하고, "메시지가 없는 방을 목록 최상단에 어떻게 그릴지"에 대한 기획 확인이 선행되어야 해서 이번 PR에서는 제외했습니다. 정렬 쿼리 자체는 `findActiveRoomIdsSortedByActivity` 한 곳이라 후속 작업 범위는 작습니다.

**3. `rejoin()`은 `leftAt`을 초기화하지 않습니다**

의도된 동작입니다. 재입장 후에도 나가기 이전 대화는 계속 숨겨져야 하며, 이는 기존 `getMessages()`의 동작과 일치합니다.
