### PR TITLE
[REFACTOR/API] 관리자 쿠폰/신고 permitAll 제거 및 관리자 인증 적용

### DIFF
--- a/devine-api/src/main/java/com/umc/devine/admin/complaint/controller/ComplaintController.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/complaint/controller/ComplaintController.java
@@ -1,17 +1,17 @@
 package com.umc.devine.admin.complaint.controller;
 
+import com.umc.devine.admin.auth.security.AdminPrincipal;
 import com.umc.devine.admin.complaint.dto.ComplaintReqDTO;
 import com.umc.devine.admin.complaint.dto.ComplaintResDTO;
 import com.umc.devine.admin.complaint.exception.code.ComplaintSuccessCode;
 import com.umc.devine.admin.complaint.service.command.ComplaintCommandService;
 import com.umc.devine.admin.complaint.service.query.ComplaintQueryService;
-import com.umc.devine.domain.member.entity.Member;
 import com.umc.devine.global.apiPayload.ApiResponse;
 import com.umc.devine.global.dto.PagedResponse;
-import com.umc.devine.global.security.CurrentMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,12 +43,11 @@ public class ComplaintController implements ComplaintControllerDocs {
     @Override
     @PatchMapping("/{complaintId}/status")
     public ApiResponse<ComplaintResDTO.UpdateStatusRes> updateStatus(
-            @CurrentMember(required = false) Member member,
+            @AuthenticationPrincipal AdminPrincipal admin,
             @PathVariable Long complaintId,
             @RequestBody @Valid ComplaintReqDTO.UpdateStatusReq request
     ) {
-        Long processorMemberId = member != null ? member.getId() : null;
-        ComplaintResDTO.UpdateStatusRes response = complaintCommandService.updateStatus(complaintId, processorMemberId, request);
+        ComplaintResDTO.UpdateStatusRes response = complaintCommandService.updateStatus(complaintId, admin.getClerkId(), request);
         return ApiResponse.onSuccess(ComplaintSuccessCode.STATUS_UPDATED, response);
     }
 }

--- a/devine-api/src/main/java/com/umc/devine/admin/complaint/controller/ComplaintControllerDocs.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/complaint/controller/ComplaintControllerDocs.java
@@ -1,24 +1,21 @@
 package com.umc.devine.admin.complaint.controller;
 
+import com.umc.devine.admin.auth.security.AdminPrincipal;
 import com.umc.devine.admin.complaint.dto.ComplaintReqDTO;
 import com.umc.devine.admin.complaint.dto.ComplaintResDTO;
-import com.umc.devine.domain.member.entity.Member;
 import com.umc.devine.global.apiPayload.ApiResponse;
 import com.umc.devine.global.dto.PagedResponse;
-import com.umc.devine.global.security.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-/**
- * TODO: 관리자 인증/인가 기능이 추가되면 관리자 권한 검증을 추가.
- */
 @Tag(name = "Admin Complaint", description = "관리자 신고/제재 관리 API")
 public interface ComplaintControllerDocs {
 
@@ -46,7 +43,7 @@ public interface ComplaintControllerDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "신고를 찾을 수 없음")
     })
     ApiResponse<ComplaintResDTO.UpdateStatusRes> updateStatus(
-            @Parameter(hidden = true) @CurrentMember(required = false) Member member,
+            @Parameter(hidden = true) @AuthenticationPrincipal AdminPrincipal admin,
             @Parameter(description = "신고 ID", required = true) @PathVariable Long complaintId,
             @RequestBody @Valid ComplaintReqDTO.UpdateStatusReq request
     );

--- a/devine-api/src/main/java/com/umc/devine/admin/complaint/service/command/ComplaintCommandService.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/complaint/service/command/ComplaintCommandService.java
@@ -5,5 +5,5 @@ import com.umc.devine.admin.complaint.dto.ComplaintResDTO;
 
 public interface ComplaintCommandService {
 
-    ComplaintResDTO.UpdateStatusRes updateStatus(Long complaintId, Long processorMemberId, ComplaintReqDTO.UpdateStatusReq request);
+    ComplaintResDTO.UpdateStatusRes updateStatus(Long complaintId, String processorClerkId, ComplaintReqDTO.UpdateStatusReq request);
 }

--- a/devine-api/src/main/java/com/umc/devine/admin/complaint/service/command/ComplaintCommandServiceImpl.java
+++ b/devine-api/src/main/java/com/umc/devine/admin/complaint/service/command/ComplaintCommandServiceImpl.java
@@ -35,7 +35,7 @@ public class ComplaintCommandServiceImpl implements ComplaintCommandService {
     private final ProjectRepository projectRepository;
 
     @Override
-    public ComplaintResDTO.UpdateStatusRes updateStatus(Long complaintId, Long processorMemberId, ComplaintReqDTO.UpdateStatusReq request) {
+    public ComplaintResDTO.UpdateStatusRes updateStatus(Long complaintId, String processorClerkId, ComplaintReqDTO.UpdateStatusReq request) {
         Complaint complaint = complaintRepository.findById(complaintId)
                 .orElseThrow(() -> new ComplaintException(ComplaintErrorReason.COMPLAINT_NOT_FOUND));
 
@@ -60,7 +60,7 @@ public class ComplaintCommandServiceImpl implements ComplaintCommandService {
             }
         }
 
-        Member resolver = processorMemberId != null ? memberRepository.findById(processorMemberId).orElse(null) : null;
+        Member resolver = processorClerkId != null ? memberRepository.findByClerkId(processorClerkId).orElse(null) : null;
 
         complaint.updateStatus(request.status(), action, resolutionReason, resolver, resolvedAt);
 

--- a/devine-api/src/main/java/com/umc/devine/global/config/ApiSecurityConfig.java
+++ b/devine-api/src/main/java/com/umc/devine/global/config/ApiSecurityConfig.java
@@ -119,10 +119,6 @@ public class ApiSecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/payments/webhook").permitAll()
                         // 개발용 토큰 발급 페이지
                         .requestMatchers("/dev", "/dev/**").permitAll()
-                        // 관리자 쿠폰 관리 (관리자 인증/인가 미구현 - TODO: 인증 붙으면 permitAll 제거)
-                        .requestMatchers("/admin/v1/coupon/**").permitAll()
-                        // 관리자 신고/제재 관리 (관리자 인증/인가 미구현 - TODO: 인증 붙으면 permitAll 제거)
-                        .requestMatchers("/admin/v1/complaints/**").permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/devine-api/src/test/java/com/umc/devine/admin/complaint/controller/ComplaintControllerTest.java
+++ b/devine-api/src/test/java/com/umc/devine/admin/complaint/controller/ComplaintControllerTest.java
@@ -20,8 +20,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import com.umc.devine.global.security.ClerkPrincipal;
+import com.umc.devine.admin.auth.security.AdminPrincipal;
+import com.umc.devine.admin.enums.AdminLevel;
+
+import java.util.List;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -63,17 +67,14 @@ class ComplaintControllerTest extends ControllerIntegrationTestSupport {
                 .used(MemberStatus.ACTIVE)
                 .build());
 
-        Member admin = memberRepository.save(Member.builder()
+        AdminPrincipal principal = AdminPrincipal.builder()
                 .clerkId("clerk_admin")
+                .email("admin@example.com")
                 .name("관리자")
-                .nickname("admin")
-                .mainType(MemberMainType.PM)
-                .disclosure(true)
-                .used(MemberStatus.ACTIVE)
-                .build());
-
-        ClerkPrincipal principal = new ClerkPrincipal("clerk_admin", "admin@example.com", "관리자", null);
-        adminAuth = new UsernamePasswordAuthenticationToken(principal, null, java.util.Collections.emptyList());
+                .level(AdminLevel.ADMIN)
+                .build();
+        adminAuth = new UsernamePasswordAuthenticationToken(
+                principal, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
     }
 
     private Complaint createComplaint(ComplaintStatus status) {
@@ -92,13 +93,14 @@ class ComplaintControllerTest extends ControllerIntegrationTestSupport {
     class GetComplaintListTest {
 
         @Test
-        @DisplayName("인증 없이도 신고 목록을 조회할 수 있다")
+        @DisplayName("관리자는 신고 목록을 조회할 수 있다")
         void getComplaintList_success() throws Exception {
             // given
             createComplaint(ComplaintStatus.PENDING);
 
             // when & then
             mockMvc.perform(get("/admin/v1/complaints")
+                            .with(authentication(adminAuth))
                             .contentType(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -119,6 +121,7 @@ class ComplaintControllerTest extends ControllerIntegrationTestSupport {
 
             // when & then
             mockMvc.perform(get("/admin/v1/complaints/{complaintId}", complaint.getId())
+                            .with(authentication(adminAuth))
                             .contentType(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -130,6 +133,7 @@ class ComplaintControllerTest extends ControllerIntegrationTestSupport {
         @DisplayName("존재하지 않는 신고ID면 404를 반환한다")
         void getComplaintDetail_notFound() throws Exception {
             mockMvc.perform(get("/admin/v1/complaints/{complaintId}", 999999L)
+                            .with(authentication(adminAuth))
                             .contentType(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isNotFound())

--- a/devine-api/src/test/java/com/umc/devine/admin/complaint/service/command/ComplaintCommandServiceTest.java
+++ b/devine-api/src/test/java/com/umc/devine/admin/complaint/service/command/ComplaintCommandServiceTest.java
@@ -136,7 +136,7 @@ class ComplaintCommandServiceTest extends IntegrationTestSupport {
                     .build();
 
             // when & then
-            assertThatThrownBy(() -> complaintCommandService.updateStatus(999999L, admin.getId(), request))
+            assertThatThrownBy(() -> complaintCommandService.updateStatus(999999L, admin.getClerkId(), request))
                     .isInstanceOf(ComplaintException.class);
         }
 
@@ -150,7 +150,7 @@ class ComplaintCommandServiceTest extends IntegrationTestSupport {
                     .build();
 
             // when
-            ComplaintResDTO.UpdateStatusRes result = complaintCommandService.updateStatus(complaint.getId(), admin.getId(), request);
+            ComplaintResDTO.UpdateStatusRes result = complaintCommandService.updateStatus(complaint.getId(), admin.getClerkId(), request);
 
             // then
             assertThat(result.status()).isEqualTo(ComplaintStatus.IN_REVIEW);
@@ -168,7 +168,7 @@ class ComplaintCommandServiceTest extends IntegrationTestSupport {
                     .build();
 
             // when & then
-            assertThatThrownBy(() -> complaintCommandService.updateStatus(complaint.getId(), admin.getId(), request))
+            assertThatThrownBy(() -> complaintCommandService.updateStatus(complaint.getId(), admin.getClerkId(), request))
                     .isInstanceOf(ComplaintException.class);
         }
 
@@ -183,7 +183,7 @@ class ComplaintCommandServiceTest extends IntegrationTestSupport {
                     .build();
 
             // when & then
-            assertThatThrownBy(() -> complaintCommandService.updateStatus(complaint.getId(), admin.getId(), request))
+            assertThatThrownBy(() -> complaintCommandService.updateStatus(complaint.getId(), admin.getClerkId(), request))
                     .isInstanceOf(ComplaintException.class);
         }
 
@@ -199,7 +199,7 @@ class ComplaintCommandServiceTest extends IntegrationTestSupport {
                     .build();
 
             // when
-            ComplaintResDTO.UpdateStatusRes result = complaintCommandService.updateStatus(complaint.getId(), admin.getId(), request);
+            ComplaintResDTO.UpdateStatusRes result = complaintCommandService.updateStatus(complaint.getId(), admin.getClerkId(), request);
 
             // then
             assertThat(result.status()).isEqualTo(ComplaintStatus.COMPLETED);
@@ -221,7 +221,7 @@ class ComplaintCommandServiceTest extends IntegrationTestSupport {
                     .build();
 
             // when
-            ComplaintResDTO.UpdateStatusRes result = complaintCommandService.updateStatus(complaint.getId(), admin.getId(), request);
+            ComplaintResDTO.UpdateStatusRes result = complaintCommandService.updateStatus(complaint.getId(), admin.getClerkId(), request);
 
             // then
             assertThat(result.reprocessWarning()).isTrue();
@@ -237,7 +237,7 @@ class ComplaintCommandServiceTest extends IntegrationTestSupport {
                     .build();
 
             // when
-            complaintCommandService.updateStatus(complaint.getId(), admin.getId(), request);
+            complaintCommandService.updateStatus(complaint.getId(), admin.getClerkId(), request);
 
             // then
             List<ComplaintHistory> histories = complaintHistoryRepository.findByComplaintIdOrderByCreatedAtDesc(complaint.getId());
@@ -253,9 +253,9 @@ class ComplaintCommandServiceTest extends IntegrationTestSupport {
             Complaint complaint = createComplaint(ComplaintStatus.PENDING);
 
             // when
-            complaintCommandService.updateStatus(complaint.getId(), admin.getId(),
+            complaintCommandService.updateStatus(complaint.getId(), admin.getClerkId(),
                     ComplaintReqDTO.UpdateStatusReq.builder().status(ComplaintStatus.IN_REVIEW).build());
-            complaintCommandService.updateStatus(complaint.getId(), admin.getId(),
+            complaintCommandService.updateStatus(complaint.getId(), admin.getClerkId(),
                     ComplaintReqDTO.UpdateStatusReq.builder()
                             .status(ComplaintStatus.COMPLETED)
                             .action(ComplaintAction.WARNING)
@@ -282,7 +282,7 @@ class ComplaintCommandServiceTest extends IntegrationTestSupport {
                     .build();
 
             // when
-            complaintCommandService.updateStatus(complaint.getId(), admin.getId(), request);
+            complaintCommandService.updateStatus(complaint.getId(), admin.getClerkId(), request);
 
             // then
             Project updated = projectRepository.findById(project.getId()).orElseThrow();
@@ -302,7 +302,7 @@ class ComplaintCommandServiceTest extends IntegrationTestSupport {
                     .build();
 
             // when
-            ComplaintResDTO.UpdateStatusRes result = complaintCommandService.updateStatus(complaint.getId(), admin.getId(), request);
+            ComplaintResDTO.UpdateStatusRes result = complaintCommandService.updateStatus(complaint.getId(), admin.getClerkId(), request);
 
             // then
             assertThat(result.status()).isEqualTo(ComplaintStatus.COMPLETED);
@@ -321,7 +321,7 @@ class ComplaintCommandServiceTest extends IntegrationTestSupport {
                     .build();
 
             // when
-            ComplaintResDTO.UpdateStatusRes result = complaintCommandService.updateStatus(complaint.getId(), admin.getId(), request);
+            ComplaintResDTO.UpdateStatusRes result = complaintCommandService.updateStatus(complaint.getId(), admin.getClerkId(), request);
 
             // then
             assertThat(result.status()).isEqualTo(ComplaintStatus.COMPLETED);

--- a/devine-api/src/test/java/com/umc/devine/admin/coupon/controller/AdminCouponControllerTest.java
+++ b/devine-api/src/test/java/com/umc/devine/admin/coupon/controller/AdminCouponControllerTest.java
@@ -1,7 +1,9 @@
 package com.umc.devine.admin.coupon.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.devine.admin.auth.security.AdminPrincipal;
 import com.umc.devine.admin.coupon.dto.AdminCouponReqDTO;
+import com.umc.devine.admin.enums.AdminLevel;
 import com.umc.devine.domain.coupon.entity.Coupon;
 import com.umc.devine.domain.coupon.enums.DiscountType;
 import com.umc.devine.domain.coupon.repository.CouponCodeRepository;
@@ -19,10 +21,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -44,9 +50,19 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
     private ObjectMapper objectMapper;
 
     private Coupon coupon;
+    private Authentication adminAuth;
 
     @BeforeEach
     void setUp() {
+        AdminPrincipal principal = AdminPrincipal.builder()
+                .clerkId("clerk_admin")
+                .email("admin@example.com")
+                .name("관리자")
+                .level(AdminLevel.ADMIN)
+                .build();
+        adminAuth = new UsernamePasswordAuthenticationToken(
+                principal, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+
         coupon = couponRepository.save(Coupon.builder()
                 .name("컨트롤러 테스트 쿠폰")
                 .discountType(DiscountType.FIXED_AMOUNT)
@@ -72,8 +88,8 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
     class CreateCoupon {
 
         @Test
-        @DisplayName("인증 없이도 쿠폰을 생성할 수 있다")
-        void createsWithoutAuthentication() throws Exception {
+        @DisplayName("관리자는 쿠폰을 생성할 수 있다")
+        void createsCoupon() throws Exception {
             AdminCouponReqDTO.CreateCouponReq request = new AdminCouponReqDTO.CreateCouponReq(
                     "신규 쿠폰", DiscountType.FIXED_RATE, 10L, null,
                     LocalDateTime.now(), LocalDateTime.now().plusDays(30),
@@ -81,6 +97,7 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
             );
 
             mockMvc.perform(post("/admin/v1/coupon")
+                            .with(authentication(adminAuth))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -98,6 +115,7 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
             );
 
             mockMvc.perform(post("/admin/v1/coupon")
+                            .with(authentication(adminAuth))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest());
@@ -111,7 +129,8 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
         @Test
         @DisplayName("쿠폰 목록을 페이징 조회한다")
         void returnsPagedList() throws Exception {
-            mockMvc.perform(get("/admin/v1/coupon").param("page", "1").param("size", "10"))
+            mockMvc.perform(get("/admin/v1/coupon").param("page", "1").param("size", "10")
+                            .with(authentication(adminAuth)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.result.content").isArray())
                     .andExpect(jsonPath("$.result.totalElements").value(1));
@@ -125,7 +144,8 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
         @Test
         @DisplayName("쿠폰 상세 정보를 조회한다")
         void returnsCouponDetail() throws Exception {
-            mockMvc.perform(get("/admin/v1/coupon/{couponId}", coupon.getId()))
+            mockMvc.perform(get("/admin/v1/coupon/{couponId}", coupon.getId())
+                            .with(authentication(adminAuth)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.result.couponId").value(coupon.getId()))
                     .andExpect(jsonPath("$.result.name").value("컨트롤러 테스트 쿠폰"));
@@ -134,7 +154,8 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
         @Test
         @DisplayName("존재하지 않는 쿠폰이면 404를 반환한다")
         void returns404WhenNotFound() throws Exception {
-            mockMvc.perform(get("/admin/v1/coupon/{couponId}", 999_999L))
+            mockMvc.perform(get("/admin/v1/coupon/{couponId}", 999_999L)
+                            .with(authentication(adminAuth)))
                     .andExpect(status().isNotFound());
         }
     }
@@ -150,6 +171,7 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
                     "수정된 이름", null, null, null, false, false, null);
 
             mockMvc.perform(patch("/admin/v1/coupon/{couponId}", coupon.getId())
+                            .with(authentication(adminAuth))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -164,6 +186,7 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
                     "이름", null, null, null, false, null, null);
 
             mockMvc.perform(patch("/admin/v1/coupon/{couponId}", 999_999L)
+                            .with(authentication(adminAuth))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isNotFound());
@@ -188,6 +211,7 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
                     AdminCouponReqDTO.IssueType.SPECIFIC, List.of(member.getNickname()), null, null, null, null);
 
             mockMvc.perform(post("/admin/v1/coupon/{couponId}/issue", coupon.getId())
+                            .with(authentication(adminAuth))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -201,6 +225,7 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
                     AdminCouponReqDTO.IssueType.CODE_GEN, null, 8, 3, null, null);
 
             mockMvc.perform(post("/admin/v1/coupon/{couponId}/issue", coupon.getId())
+                            .with(authentication(adminAuth))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -215,6 +240,7 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
                     AdminCouponReqDTO.IssueType.CODE_GEN, null, null, null, "summer2026", 50);
 
             mockMvc.perform(post("/admin/v1/coupon/{couponId}/issue", coupon.getId())
+                            .with(authentication(adminAuth))
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -230,7 +256,8 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
         @Test
         @DisplayName("쿠폰ID 없이 요청하면 전체 쿠폰 현황을 반환한다")
         void returnsAllStatsWithoutId() throws Exception {
-            mockMvc.perform(get("/admin/v1/coupon/usage"))
+            mockMvc.perform(get("/admin/v1/coupon/usage")
+                            .with(authentication(adminAuth)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.result").isArray())
                     .andExpect(jsonPath("$.result.length()").value(1));
@@ -239,7 +266,8 @@ class AdminCouponControllerTest extends ControllerIntegrationTestSupport {
         @Test
         @DisplayName("쿠폰ID를 지정하면 해당 쿠폰 현황만 반환한다")
         void returnsSingleStatWithId() throws Exception {
-            mockMvc.perform(get("/admin/v1/coupon/usage").param("couponId", coupon.getId().toString()))
+            mockMvc.perform(get("/admin/v1/coupon/usage").param("couponId", coupon.getId().toString())
+                            .with(authentication(adminAuth)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.result.length()").value(1))
                     .andExpect(jsonPath("$.result[0].couponId").value(coupon.getId()));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호
- issue #324 

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

관리자 쿠폰/신고 API에 관리자 인증(`adminSecurityFilterChain`, ROLE_ADMIN)을 적용합니다.

#299 병합으로 관리자 인증 체계가 확정됐지만, 쿠폰(`/admin/v1/coupon/**`)과 신고(`/admin/v1/complaints/**`)는 임시 `permitAll`이 그대로 남아있었습니다. 이번 PR에서 정리했습니다.

**변경 사항**

- `ApiSecurityConfig`에서 두 경로의 임시 `permitAll` 매처를 제거했습니다.
  - `adminSecurityFilterChain`이 이미 `/admin/**` 전체를 처리하기 때문에 불필요합니다.
- `ComplaintController.updateStatus`에서 처리자(processor) 기록 버그를 발견하고 수정했습니다.
  - 기존 `@CurrentMember(required = false)`는 `ClerkPrincipal`일 때만 동작합니다.
  - 관리자 인증 체계에서는 principal이 `AdminPrincipal`이라, 이 애너테이션이 항상 `null`을 반환하고 있었습니다.
  - 그 결과 신고 처리 이력에 "누가 처리했는지"가 기록되지 않는 버그였습니다.
  - `@AuthenticationPrincipal AdminPrincipal admin`으로 관리자를 직접 받도록 바꿨습니다.
  - `clerkId`를 서비스로 전달해서 처리자 `Member`를 조회하도록 수정했습니다.
  - `ComplaintCommandService.updateStatus` 시그니처를 `processorMemberId(Long)`에서 `processorClerkId(String)`으로 변경했습니다.

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

`./gradlew :devine-core:test :devine-api:test` 전체 통과했습니다.

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요